### PR TITLE
lldp: avoid memory leak from bad packets

### DIFF
--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -816,11 +816,16 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 				goto malformed;
 			}
 			PEEK_BYTES(b, tlv_size);
-			if (tlv_type == LLDP_TLV_PORT_DESCR)
+			if (tlv_type == LLDP_TLV_PORT_DESCR) {
+				free(port->p_descr);
 				port->p_descr = b;
-			else if (tlv_type == LLDP_TLV_SYSTEM_NAME)
+			} else if (tlv_type == LLDP_TLV_SYSTEM_NAME) {
+				free(chassis->c_name);
 				chassis->c_name = b;
-			else chassis->c_descr = b;
+			} else {
+				free(chassis->c_descr);
+				chassis->c_descr = b;
+			}
 			break;
 		case LLDP_TLV_SYSTEM_CAP:
 			CHECK_TLV_SIZE(4, "System capabilities");


### PR DESCRIPTION
A packet that contains multiple instances of certain TLVs will cause
lldpd to continually allocate memory and leak the old memory.  As an
example, multiple instances of system name TLV will cause old values
to be dropped by the decoding routine.

Reported-at: https://github.com/openvswitch/ovs/pull/337
Reported-by: Jonas Rudloff <jonas.t.rudloff@gmail.com>
Signed-off-by: Aaron Conole <aconole@redhat.com>