### PR TITLE
routing/linux: check IPv6 forwarding status when enabling Router capa

### DIFF
--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -61,6 +61,7 @@
 struct event;
 struct event_base;
 
+#define PROCFS_SYS_NET	"/proc/sys/net/"
 #define SYSFS_CLASS_NET "/sys/class/net/"
 #define SYSFS_CLASS_DMI "/sys/class/dmi/id/"
 #define LLDPD_TX_INTERVAL	30

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -58,7 +58,8 @@ void
 asroot_open()
 {
 	const char* authorized[] = {
-		"/proc/sys/net/ipv4/ip_forward",
+		PROCFS_SYS_NET "ipv4/ip_forward",
+		PROCFS_SYS_NET "ipv6/conf/all/forwarding",
 		"/proc/net/bonding/[^.][^/]*",
 		"/proc/self/net/bonding/[^.][^/]*",
 #ifdef ENABLE_OLDIES


### PR DESCRIPTION
This PR addresses issue #425 

While at it, the style of the existing code has been improved a bit.