### PR TITLE
tests: don't install libxml2 on MacOS

### DIFF
--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -9,7 +9,6 @@ case "$(uname -s)" in
 brew "automake"
 brew "autoconf"
 brew "libtool"
-brew "libxml2"
 brew "check"
 EOS
         ;;


### PR DESCRIPTION
It is shipped and Homebrew will fail if we try to install it.