### PR TITLE
lldpd: override compiler and linker option strings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -382,8 +382,16 @@ fi
 
 AX_BUILD_DATE_EPOCH(BUILD_DATE, "%FT%TZ", [BUILD_DATE="(unknown)"])
 AC_DEFINE_UNQUOTED(BUILD_DATE, "[$BUILD_DATE]", [Build date and time])
+
+dnl per reproducible-builds.org check SOURCE_DATE_EPOCH
+dnl
+if test -z "${SOURCE_DATE_EPOCH+set}" ; then
 AC_DEFINE_UNQUOTED(LLDP_CC, "[$CC $LLDP_CFLAGS $LLDP_CPPFLAGS $CFLAGS $CPPFLAGS]", [C compiler command])
 AC_DEFINE_UNQUOTED(LLDP_LD, "[$LD $LLDP_LDFLAGS $LLDP_BIN_LDFLAGS $LDFLAGS $LIBS]", [Linker compiler command])
+else
+AC_DEFINE_UNQUOTED(LLDP_CC, "[C compiler command is not available for reproducible builds]", [C compiler command])
+AC_DEFINE_UNQUOTED(LLDP_LD, "[Linker compiler command is not available for reproducible builds]", [Linker compiler command])
+fi
 
 #######################
 # Output results


### PR DESCRIPTION
Compiler and linker option could contain absolute path, so
replace them with disclaimer. Those strings used only as
debug information to show not actual compilation options.

Signed-off-by: Oleksiy Obitotskyy <oobitots@cisco.com>