### PR TITLE
Fix relative include paths to be more correct and portable.

### DIFF
--- a/src/daemon/protocols/cdp.c
+++ b/src/daemon/protocols/cdp.c
@@ -16,8 +16,8 @@
  */
 
 /* We also supports FDP which is very similar to CDPv1 */
-#include "lldpd.h"
-#include "frame.h"
+#include "../lldpd.h"
+#include "../frame.h"
 
 /*
  * CDP Requests Power at the switch output and therefore has to take into

--- a/src/daemon/protocols/edp.c
+++ b/src/daemon/protocols/edp.c
@@ -15,8 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "lldpd.h"
-#include "frame.h"
+#include "../lldpd.h"
+#include "../frame.h"
 
 #ifdef ENABLE_EDP
 

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -15,8 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "lldpd.h"
-#include "frame.h"
+#include "../lldpd.h"
+#include "../frame.h"
 
 #include <unistd.h>
 #include <errno.h>

--- a/src/daemon/protocols/sonmp.c
+++ b/src/daemon/protocols/sonmp.c
@@ -15,8 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "lldpd.h"
-#include "frame.h"
+#include "../lldpd.h"
+#include "../frame.h"
 
 #ifdef ENABLE_SONMP
 

--- a/src/lib/atoms/chassis.c
+++ b/src/lib/atoms/chassis.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 static lldpctl_map_t chassis_id_subtype_map[] = {
 	{ LLDP_CHASSISID_SUBTYPE_IFNAME,  "ifname"},

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -21,9 +21,9 @@
 #include <arpa/inet.h>
 
 #include "../lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 static struct atom_map bond_slave_src_mac_map = {
 	.key = lldpctl_k_config_bond_slave_src_mac_type,

--- a/src/lib/atoms/custom.c
+++ b/src/lib/atoms/custom.c
@@ -21,10 +21,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 #ifdef ENABLE_CUSTOM
 

--- a/src/lib/atoms/dot1.c
+++ b/src/lib/atoms/dot1.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 #ifdef ENABLE_DOT1
 

--- a/src/lib/atoms/dot3.c
+++ b/src/lib/atoms/dot3.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 #ifdef ENABLE_DOT3
 

--- a/src/lib/atoms/interface.c
+++ b/src/lib/atoms/interface.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 static int
 _lldpctl_atom_new_interfaces_list(lldpctl_atom_t *atom, va_list ap)

--- a/src/lib/atoms/med.c
+++ b/src/lib/atoms/med.c
@@ -20,11 +20,11 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
-#include "fixedpoint.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
+#include "../fixedpoint.h"
 
 #ifdef ENABLE_LLDPMED
 

--- a/src/lib/atoms/mgmt.c
+++ b/src/lib/atoms/mgmt.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 static int
 _lldpctl_atom_new_mgmts_list(lldpctl_atom_t *atom, va_list ap)

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -20,10 +20,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "lldpctl.h"
-#include "../log.h"
-#include "atom.h"
-#include "helpers.h"
+#include "../lldpctl.h"
+#include "../../log.h"
+#include "../atom.h"
+#include "../helpers.h"
 
 static struct atom_map lldpd_protocol_map = {
 	.key = lldpctl_k_port_protocol,


### PR DESCRIPTION
Some relative include paths in subdirectories (src/daemon/protocols
and src/lib/atoms) were written relative to the parent directories
(src/daemon and src/lib).  This was okay in automake builds but
caused errors when porting to other build systems (for example,
Android make).