### PR TITLE
Eliminate unused arguments to priv_init() with --disable-privsep.

### DIFF
--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1844,7 +1844,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 #ifdef ENABLE_PRIVSEP
 	priv_init(PRIVSEP_CHROOT, ctl, uid, gid);
 #else
-	priv_init(PRIVSEP_CHROOT, ctl, 0, 0);
+	priv_init();
 #endif
 
 	/* Initialization of global configuration */

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -194,7 +194,11 @@ client_handle_client(struct lldpd *cfg,
     int*);
 
 /* priv.c */
+#ifdef ENABLE_PRIVSEP
 void	 priv_init(const char*, int, uid_t, gid_t);
+#else
+void	 priv_init(void);
+#endif
 void	 priv_wait(void);
 void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostname(void);

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -682,7 +682,11 @@ priv_caps(uid_t uid, gid_t gid)
 }
 
 void
+#ifdef ENABLE_PRIVSEP
 priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
+#else
+priv_init(void)
+#endif
 {
 
 	int pair[2];


### PR DESCRIPTION
This seems a bit cleaner than passing dummy values (e.g. 0) that
aren't ever used.  Additionally, it means that PRIVSEP_CHROOT no
longer needs to be defined to a dummy value if building with
--disable-privsep.