### PR TITLE
interfaces-bsd: do not consider an interface when it is down

### DIFF
--- a/src/daemon/interfaces-bsd.c
+++ b/src/daemon/interfaces-bsd.c
@@ -433,6 +433,15 @@ ifbsd_extract(struct lldpd *cfg,
 		    "grabbing information on interface %s",
 		    ifaddr->ifa_name);
 		device = ifbsd_extract_device(cfg, ifaddr);
+#if defined HOST_OS_OPENBSD
+		/* On OpenBSD, the interface can have IFF_RUNNING but be down. */
+		{
+			struct if_data *ifdata;
+			ifdata = ifaddr->ifa_data;
+			if (!LINK_STATE_IS_UP(ifdata->ifi_link_state))
+				device->flags &= ~IFF_RUNNING;
+		}
+#endif
 		if (device)
 			TAILQ_INSERT_TAIL(interfaces, device, next);
 		break;


### PR DESCRIPTION
At least on OpenBSD, an interface can be oper down while
`IFF_RUNNING`. Check the link state and removes the `IFF_RUNNING` flag
in this case. This should also work for FreeBSD and NetBSD, but it may
not be needed.

Fix #474