### PR TITLE
doc: replace the old py.test references by pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ that:
     afl-fuzz -i inputs -o outputs ./decode @@
 
 There is a general test suite with `make check`. It's also possible to
-run integration tests. They need [py.test](http://pytest.org/latest/)
+run integration tests. They need [pytest](http://pytest.org/latest/)
 and rely on Linux containers to be executed.
 
 To enable code coverage, use:

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -2,5 +2,5 @@
 __pycache__
 *.pyc
 
-# py.test
-/.cache
+# pytest
+/.pytest_cache

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -16,6 +16,6 @@ _lldpd user.
 
 Then, tests can be run with:
 
-    $ sudo $(which py.test) -vv -n 10 --boxed
+    $ sudo $(which pytest) -vv -n 10 --boxed
 
 Add an additional `-v` to get even more traces.


### PR DESCRIPTION
Also update the name of pytest's cachedir.