### PR TITLE
Fix issue #490 - when receiving del event we will execute it immediately (without timer)

### DIFF
--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -434,6 +434,7 @@ struct lldpd {
 
 #ifdef HOST_OS_LINUX
 	struct lldpd_netlink	*g_netlink;
+	int del_link_operation;
 #endif
 
 	struct lldpd_port	*g_default_local_port;

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -730,6 +730,11 @@ retry:
 				    "received unhandled message type %d (len: %d)",
 				    msg->nlmsg_type, msg->nlmsg_len);
 			}
+            if (msg->nlmsg_type == RTM_DELLINK) {
+                cfg->del_link_operation = 1;
+            } else {
+                cfg->del_link_operation = 0;
+            }
 		}
 	}
 end:


### PR DESCRIPTION
Signed-off-by: tomeri <tomeri@nvidia.com>

this PR will fix this issue:
https://github.com/lldpd/lldpd/issues/490

in order to recreate the socket when we remove a port and add it immediately, we can execute the delete action immediately without using the timer.

another way to solve it is to check [here](https://github.com/lldpd/lldpd/blob/690e447ea0a9cd488b953b95b3f1c86c8a526e03/src/daemon/lldpd.c#L150) if the new ifindex is equal to the current ifindex - if they are different we need to recreate the socket (levent_hardware_release & levent_hardware_init)

