### PR TITLE
interfaces: detect interface index changes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 lldpd (1.0.14)
  * Fix:
    + Update seccomp rules for newer kernel/libc (#488)
+   + Correctly handle an interface whose index has changed (#490)
 
 lldpd (1.0.13)
  * Fix:

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -803,7 +803,7 @@ iflinux_handle_bond(struct lldpd *cfg, struct interfaces_device_list *interfaces
 			created = 1;
 		}
 		if (hardware->h_flags) continue;
-		if (hardware->h_ops != &bond_ops) {
+		if (hardware->h_ops != &bond_ops || hardware->h_ifindex_changed) {
 			if (!created) {
 				log_debug("interfaces",
 				    "bond %s is converted from another type of interface",
@@ -822,7 +822,7 @@ iflinux_handle_bond(struct lldpd *cfg, struct interfaces_device_list *interfaces
 		} else bmaster = hardware->h_data;
 		bmaster->index = master->index;
 		strlcpy(bmaster->name, master->name, IFNAMSIZ);
-		if (hardware->h_ops != &bond_ops) {
+		if (hardware->h_ops != &bond_ops || hardware->h_ifindex_changed) {
 			if (iface_bond_init(cfg, hardware) != 0) {
 				log_warn("interfaces", "unable to initialize %s",
 				    hardware->h_ifname);

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -679,7 +679,7 @@ interfaces_helper_physical(struct lldpd *cfg,
 		}
 		if (hardware->h_flags)
 			continue;
-		if (hardware->h_ops != ops) {
+		if (hardware->h_ops != ops || hardware->h_ifindex_changed) {
 			if (!created) {
 				log_debug("interfaces",
 				    "interface %s is converted from another type of interface",

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -474,6 +474,7 @@ struct lldpd_hardware {
 					     removed if this is left
 					     to 0. */
 	int			 h_ifindex; /* Interface index, used by SNMP */
+	int			 h_ifindex_changed;  /* Interface index has changed */
 	char			 h_ifname[IFNAMSIZ]; /* Should be unique */
 	u_int8_t		 h_lladdr[ETHER_ADDR_LEN];
 


### PR DESCRIPTION
When an interface is deleted and recreated, we didn't detect any
change and just updated its index. However, the handles we had on this
interface are now invalid. Ensure the interface is correctly
reinitialized in this case.

Fix #490.