### PR TITLE
med: Add configure inventory commands

### DIFF
--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -13,7 +13,7 @@ uninstall-local:
 	cd $(DESTDIR)$(sbindir) && rm -f lldpctl
 
 lldpcli_SOURCES  = client.h lldpcli.c display.c \
-	conf.c conf-med.c conf-dot3.c conf-power.c \
+	conf.c conf-med.c conf-inv.c conf-dot3.c conf-power.c \
 	conf-lldp.c conf-system.c \
 	commands.c show.c \
 	misc.c tokenizer.c \

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -148,6 +148,7 @@ void register_commands_configure(struct cmd_node *);
 void register_commands_configure_system(struct cmd_node *, struct cmd_node *);
 void register_commands_configure_lldp(struct cmd_node *, struct cmd_node *);
 void register_commands_configure_med(struct cmd_node *, struct cmd_node *);
+void register_commands_configure_inventory(struct cmd_node *, struct cmd_node *);
 void register_commands_configure_dot3(struct cmd_node *);
 void register_commands_medpow(struct cmd_node *);
 void register_commands_dot3pow(struct cmd_node *);

--- a/src/client/conf-inv.c
+++ b/src/client/conf-inv.c
@@ -1,0 +1,215 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * SPDX-FileCopyrightText: 2022 Koninklijke Philips N.V.
+ * SPDX-License-Identifier: ISC
+ */
+
+#include <unistd.h>
+#include <string.h>
+
+#include "client.h"
+#include "../log.h"
+
+static int
+cmd_inventory(struct lldpctl_conn_t *conn, struct writer *w,
+    struct cmd_env *env, void *arg)
+{
+	log_debug("lldpctl", "configure inventory information");
+
+	lldpctl_atom_t *chassis = lldpctl_get_local_chassis(conn);
+
+	if (chassis == NULL) {
+		log_warnx("lldpctl", "unable to get configuration from lldpd. %s",
+		    lldpctl_last_strerror(conn));
+		return 0;
+	}
+
+	char *action = arg;
+	if ((!strcmp(action, "hardware-revision") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_hw,
+		    cmdenv_get(env, "hardware-revision")) == NULL)) ||
+	    (!strcmp(action, "software-revision") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_sw,
+		    cmdenv_get(env, "software-revision")) == NULL)) ||
+	    (!strcmp(action, "firmware-revision") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_fw,
+		    cmdenv_get(env, "firmware-revision")) == NULL)) ||
+	    (!strcmp(action, "serial-number") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_sn,
+		    cmdenv_get(env, "serial-number")) == NULL)) ||
+	    (!strcmp(action, "manufacturer") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_manuf,
+		    cmdenv_get(env, "manufacturer")) == NULL)) ||
+	    (!strcmp(action, "model") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_model,
+		    cmdenv_get(env, "model")) == NULL)) ||
+	    (!strcmp(action, "asset") &&
+		(lldpctl_atom_set_str(chassis,
+		    lldpctl_k_chassis_med_inventory_asset,
+		    cmdenv_get(env, "asset")) == NULL))) {
+		log_warnx("lldpctl", "Unable to setup inventory. %s",
+		    lldpctl_last_strerror(conn));
+		lldpctl_atom_dec_ref(chassis);
+		return 0;
+	}
+
+	log_info("lldpctl", "Configuration for inventory is applied");
+	lldpctl_atom_dec_ref(chassis);
+	return 1;
+}
+
+/**
+ * Register `configure inventory *` commands
+ *
+ */
+static void
+register_commands_inv(struct cmd_node *configure_inv, struct cmd_node *unconfigure_inv)
+{
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "hardware-revision", "Set hardware-revision string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory hardware-revision string",
+			NULL, cmd_store_env_value, "hardware-revision"),
+		NEWLINE, "Set hardware-revision string",
+		NULL, cmd_inventory, "hardware-revision");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "hardware-revision", "Unset hardware-revision string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset hardware-revision string",
+		NULL, cmd_inventory, "hardware-revision");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "software-revision", "Set software-revision string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory software-revision string",
+			NULL, cmd_store_env_value, "software-revision"),
+		NEWLINE, "Set software-revision string",
+		NULL, cmd_inventory, "software-revision");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "software-revision", "Unset software-revision string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset software-revision string",
+		NULL, cmd_inventory, "software-revision");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "firmware-revision", "Set firmware-revision string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory firmware-revision string",
+			NULL, cmd_store_env_value, "firmware-revision"),
+		NEWLINE, "Set firmware-revision string",
+		NULL, cmd_inventory, "firmware-revision");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "firmware-revision", "Unset firmware-revision string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset firmware-revision string",
+		NULL, cmd_inventory, "firmware-revision");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "serial-number", "Set serial-number string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory serial-number string",
+			NULL, cmd_store_env_value, "serial-number"),
+		NEWLINE, "Set serial-number string",
+		NULL, cmd_inventory, "serial-number");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "serial-number", "Unset serial-number string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset serial-number string",
+		NULL, cmd_inventory, "serial-number");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "manufacturer", "Set manufacturer string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory manufacturer string",
+			NULL, cmd_store_env_value, "manufacturer"),
+		NEWLINE, "Set manufacturer string",
+		NULL, cmd_inventory, "manufacturer");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "manufacturer", "Unset manufacturer string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset manufacturer string",
+		NULL, cmd_inventory, "manufacturer");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "model", "Set model string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory model string",
+			NULL, cmd_store_env_value, "model"),
+		NEWLINE, "Set model string",
+		NULL, cmd_inventory, "model");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "model", "Unset model string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset model string",
+		NULL, cmd_inventory, "model");
+
+	commands_new(
+		commands_new(
+			commands_new(configure_inv,
+			    "asset", "Set asset string",
+			    NULL, NULL, NULL),
+			NULL, "Inventory asset string",
+			NULL, cmd_store_env_value, "asset"),
+		NEWLINE, "Set asset string",
+		NULL, cmd_inventory, "asset");
+
+	commands_new(
+		commands_new(unconfigure_inv,
+		    "asset", "Unset asset string",
+		    NULL, NULL, NULL),
+		NEWLINE, "Unset asset string",
+		NULL, cmd_inventory, "asset");
+}
+
+/**
+ * Register `configure inventory *`
+ *
+ */
+void
+register_commands_configure_inventory(struct cmd_node *configure, struct cmd_node *unconfigure) {
+	if(lldpctl_key_get_map(
+		    lldpctl_k_med_policy_type)[0].value <= 0)
+		return;
+
+	struct cmd_node *configure_inv = commands_new(
+		configure,
+		"inventory", "Inventory configuration",
+		NULL, NULL, NULL);
+	struct cmd_node *unconfigure_inv = commands_new(
+		unconfigure,
+		"inventory", "Inventory configuration",
+		NULL, NULL, NULL);
+
+	register_commands_inv(configure_inv, unconfigure_inv);
+}
+

--- a/src/client/conf.c
+++ b/src/client/conf.c
@@ -45,5 +45,6 @@ register_commands_configure(struct cmd_node *root)
 	register_commands_configure_system(configure, unconfigure);
 	register_commands_configure_lldp(configure, unconfigure);
 	register_commands_configure_med(configure, unconfigure);
+	register_commands_configure_inventory(configure, unconfigure);
 	register_commands_configure_dot3(configure);
 }

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -839,6 +839,97 @@ A valid use of this command is:
 .Ed
 
 .Cd configure
+.Cd inventory hardware-revision Ar value
+.Bd -ragged -offset XXXXXX
+Override hardware-revision with the provided value. By default, the
+hardware-revision is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory hardware-revision
+.Bd -ragged -offset XXXXXX
+Do not override hardware-revision and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
+.Cd inventory software-revision Ar value
+.Bd -ragged -offset XXXXXX
+Override software-revision with the provided value. By default, the
+software-revision is fetched from uname
+.Ed
+
+.Cd unconfigure
+.Cd inventory software-revision
+.Bd -ragged -offset XXXXXX
+Do not override software-revision and restore the use of the uname value.
+.Ed
+
+.Cd configure
+.Cd inventory firmware-revision Ar value
+.Bd -ragged -offset XXXXXX
+Override firmware-revision with the provided value. By default, the
+firmware-revision is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory firmware-revision
+.Bd -ragged -offset XXXXXX
+Do not override firmware-revision and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
+.Cd inventory serial-number Ar value
+.Bd -ragged -offset XXXXXX
+Override serial-number with the provided value. By default, the
+serial-number is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory serial-number
+.Bd -ragged -offset XXXXXX
+Do not override serial-number and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
+.Cd inventory manufacturer Ar value
+.Bd -ragged -offset XXXXXX
+Override manufacturer with the provided value. By default, the
+manufacturer is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory manufacturer
+.Bd -ragged -offset XXXXXX
+Do not override manufacturer and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
+.Cd inventory model Ar value
+.Bd -ragged -offset XXXXXX
+Override model with the provided value. By default, the
+model is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory model
+.Bd -ragged -offset XXXXXX
+Do not override model and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
+.Cd inventory asset Ar value
+.Bd -ragged -offset XXXXXX
+Override asset with the provided value. By default, the
+asset is fetched from /sys/class/dmi
+.Ed
+
+.Cd unconfigure
+.Cd inventory asset
+.Bd -ragged -offset XXXXXX
+Do not override asset and restore the use of the /sys/class/dmi value.
+.Ed
+
+.Cd configure
 .Op ports Ar ethX Op ,...
 .Cd med power pse | pd
 .Cd source Ar source

--- a/src/ctl.h
+++ b/src/ctl.h
@@ -30,6 +30,7 @@ enum hmsg_type {
 	GET_CONFIG,	        /* Get global configuration */
 	SET_CONFIG,		/* Change global configuration */
 	GET_INTERFACES,		/* Get list of interfaces */
+	SET_CHASSIS,		/* Set local chassis */
 	GET_CHASSIS,		/* Get local chassis */
 	GET_INTERFACE,		/* Get all information related to an interface */
 	GET_DEFAULT_PORT,	/* Get all information related to default port */

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -55,6 +55,9 @@ struct lldpctl_conn_t {
 #define CONN_STATE_GET_DEFAULT_PORT_SEND 15
 #define CONN_STATE_GET_DEFAULT_PORT_RECV 16
 #define CONN_STATE_WATCHING		17
+#define CONN_STATE_SET_CHASSIS_SEND	18
+#define CONN_STATE_SET_CHASSIS_RECV	19
+
 	int state;		/* Current state */
 	/* Data attached to the state. It is used to check that we are using the
 	 * same data as a previous call until the state machine goes to

--- a/src/lib/helpers.c
+++ b/src/lib/helpers.c
@@ -71,3 +71,10 @@ _lldpctl_atom_free_any_list(lldpctl_atom_t *atom)
 	lldpctl_atom_dec_ref((lldpctl_atom_t *)plist->parent);
 }
 
+char*
+xstrdup(const char *str)
+{
+	if (!str) return NULL;
+	return strdup(str);
+}
+

--- a/src/lib/helpers.h
+++ b/src/lib/helpers.h
@@ -21,3 +21,5 @@ int map_reverse_lookup(lldpctl_map_t *list, const char *string);
 int _lldpctl_atom_new_any_list(lldpctl_atom_t *atom, va_list ap);
 void _lldpctl_atom_free_any_list(lldpctl_atom_t *atom);
 
+char *xstrdup(const char *);
+

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -800,13 +800,13 @@ typedef enum {
 
 	lldpctl_k_chassis_med_type = 1900, /**< `(IS)` Chassis MED type. See `LLDP_MED_CLASS_*` */
 	lldpctl_k_chassis_med_cap,  /**< `(I)` Available MED capabilitied. See `LLDP_MED_CAP_*` */
-	lldpctl_k_chassis_med_inventory_hw, /**< `(S)` LLDP MED inventory "Hardware Revision" */
-	lldpctl_k_chassis_med_inventory_sw, /**< `(S)` LLDP MED inventory "Software Revision" */
-	lldpctl_k_chassis_med_inventory_fw, /**< `(S)` LLDP MED inventory "Firmware Revision" */
-	lldpctl_k_chassis_med_inventory_sn, /**< `(S)` LLDP MED inventory "Serial Number" */
-	lldpctl_k_chassis_med_inventory_manuf, /**< `(S)` LLDP MED inventory "Manufacturer" */
-	lldpctl_k_chassis_med_inventory_model, /**< `(S)` LLDP MED inventory "Model" */
-	lldpctl_k_chassis_med_inventory_asset, /**< `(S)` LLDP MED inventory "Asset ID" */
+	lldpctl_k_chassis_med_inventory_hw, /**< `(S,W)` LLDP MED inventory "Hardware Revision" */
+	lldpctl_k_chassis_med_inventory_sw, /**< `(S,W)` LLDP MED inventory "Software Revision" */
+	lldpctl_k_chassis_med_inventory_fw, /**< `(S,W)` LLDP MED inventory "Firmware Revision" */
+	lldpctl_k_chassis_med_inventory_sn, /**< `(S,W)` LLDP MED inventory "Serial Number" */
+	lldpctl_k_chassis_med_inventory_manuf, /**< `(S,W)` LLDP MED inventory "Manufacturer" */
+	lldpctl_k_chassis_med_inventory_model, /**< `(S,W)` LLDP MED inventory "Model" */
+	lldpctl_k_chassis_med_inventory_asset, /**< `(S,W)` LLDP MED inventory "Asset ID" */
 
 	lldpctl_k_port_med_policies = 2000, /**< `(AL,WO)` MED policies attached to a port. */
 	lldpctl_k_med_policy_type, /**< `(IS,W)` MED policy app type. See `LLDP_MED_APPTYPE_*`. 0 if a policy is not defined. */

--- a/tests/integration/test_configinventory.py
+++ b/tests/integration/test_configinventory.py
@@ -1,0 +1,88 @@
+import os
+import pytest
+import platform
+import time
+import shlex
+
+@pytest.mark.skipif("'LLDP-MED' not in config.lldpd.features",
+                    reason="LLDP-MED not supported")
+class TestConfigInventory(object):
+
+    def test_configinventory(self, lldpd1, lldpd, lldpcli, namespaces,
+                           replace_file):
+        with namespaces(2):
+            if os.path.isdir("/sys/class/dmi/id"):
+                # /sys/class/dmi/id/*
+                for what, value in dict(product_version="1.14",
+                                        bios_version="1.10",
+                                        product_serial="45872512",
+                                        sys_vendor="Spectacular",
+                                        product_name="Workstation",
+                                        chassis_asset_tag="487122").items():
+                    replace_file("/sys/class/dmi/id/{}".format(what),
+                                value)
+            lldpd("-M", "1")
+
+        def test_default_inventory(namespaces, lldpcli):
+            with namespaces(1):
+                if os.path.isdir("/sys/class/dmi/id"):
+                    out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
+                    assert out['lldp.eth0.chassis.name'] == 'ns-2.example.com'
+                    assert out['lldp.eth0.lldp-med.inventory.hardware'] == '1.14'
+                    assert out['lldp.eth0.lldp-med.inventory.firmware'] == '1.10'
+                    assert out['lldp.eth0.lldp-med.inventory.serial'] == '45872512'
+                    assert out['lldp.eth0.lldp-med.inventory.manufacturer'] == \
+                        'Spectacular'
+                    assert out['lldp.eth0.lldp-med.inventory.model'] == 'Workstation'
+                    assert out['lldp.eth0.lldp-med.inventory.asset'] == '487122'
+                    assert out['lldp.eth0.lldp-med.inventory.software'] == \
+                        platform.release()
+                else:
+                    assert 'lldp.eth0.lldp-med.inventory.hardware' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.firmware' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.serial' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.manufacturer' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.model' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.asset' not in out.items()
+                    assert 'lldp.eth0.lldp-med.inventory.software' not in out.items()
+
+        test_default_inventory(namespaces, lldpcli)
+
+        custom_values = [
+                ('hardware-revision', 'hardware', 'SQRT2_1.41421356237309504880'),
+                ('software-revision', 'software', 'E_2.7182818284590452354'),
+                ('firmware-revision', 'firmware', 'PI_3.14159265358979323846'),
+                ('serial', 'serial', 'FIBO_112358'),
+                ('manufacturer', 'manufacturer', 'Cybertron'),
+                ('model', 'model', 'OptimusPrime'),
+                ('asset', 'asset', 'SQRT3_1.732050807568877')
+            ]
+        with namespaces(2):
+            for what, pfx, value in custom_values:
+                result = lldpcli(
+                    *shlex.split("configure inventory {} {}".format(what, value)))
+                assert result.returncode == 0
+                result = lldpcli("resume")
+                assert result.returncode == 0
+                result = lldpcli("update")
+                assert result.returncode == 0
+            time.sleep(3)
+
+        with namespaces(1):
+            out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
+            for what, pfx, value in custom_values:
+                key_to_find = "lldp.eth0.lldp-med.inventory.{}".format(pfx)
+                assert out[key_to_find] == value
+
+        with namespaces(2):
+            for what, pfx, value in custom_values:
+                result = lldpcli(
+                    *shlex.split("unconfigure inventory {}".format(what)))
+                assert result.returncode == 0
+                result = lldpcli("resume")
+                assert result.returncode == 0
+                result = lldpcli("update")
+                assert result.returncode == 0
+
+        test_default_inventory(namespaces, lldpcli)
+

--- a/tests/lldpcli.conf
+++ b/tests/lldpcli.conf
@@ -56,5 +56,21 @@ configure dot3 power pse supported enabled paircontrol powerpairs spare class cl
 configure ports eth0 dot3 power pse supported enabled paircontrol powerpairs spare class class-3
 configure dot3 power pd supported enabled powerpairs spare class class-3 type 1 source pse priority low requested 10000 allocated 15000
 
+configure inventory hardware-revision "SQRT2-1.41421356237309504880"
+configure inventory software-revision "E-2.7182818284590452354"
+configure inventory firmware-revision "PI-3.14159265358979323846"
+configure inventory serial "FIBO112358"
+configure inventory manufacturer "Cybertron"
+configure inventory model "OptimusPrime"
+configure inventory asset "SQRT3-1.732050807568877"
+
+unconfigure inventory hardware-revision
+unconfigure inventory software-revision
+unconfigure inventory firmware-revision
+unconfigure inventory serial
+unconfigure inventory manufacturer
+unconfigure inventory model
+unconfigure inventory asset
+
 # A convenient way to "test" lldpcli and liblldpctl is to load those commands in lldpcli with valgrind:
 #  libtool execute valgrind --suppressions=../src/client/lldpcli.supp --leak-check=full src/client/lldpcli -c ../tests/lldpcli.conf


### PR DESCRIPTION
Default inventory information is fetched from dmi table.
Most of embedded devices do not run EFI bootloader hence dmi information
will not be available in /sys/class/dmi

- Add `configure inventory` commands
- Add `unconfigure inventory` commands
- New code is dependent on enable-lldpmed
- Add write support on lldpctl atoms
- Add support for setting inventory configuration in daemon
- Add configinventory integration tests

Github: #498
