### PR TITLE
client: Added support to override system capabilities

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,6 @@
 lldpd (1.0.15)
+ * Changes
+   + Add configure command to override system capabilities (#526)
  * Fix:
    + Really don't send VLANs when there are too many (#520)
    + Ignore temporary IPv6 addresses (#521)

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -992,6 +992,9 @@ display_configuration(lldpctl_conn_t *conn, struct writer *w)
 	    N(lldpctl_atom_get_str(configuration, lldpctl_k_config_platform)));
 	tag_datatag(w, "hostname", "Override system name with",
 	    N(lldpctl_atom_get_str(configuration, lldpctl_k_config_hostname)));
+	tag_datatag(w, "capabilities", "Override system capabilities",
+	    lldpctl_atom_get_int(configuration, lldpctl_k_config_chassis_cap_override)?
+	    "yes":"no");
 	tag_datatag(w, "advertise-version", "Advertise version",
 	    lldpctl_atom_get_int(configuration, lldpctl_k_config_advertise_version)?
 	    "yes":"no");

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -268,6 +268,34 @@ option undoes the previous one.
 .Ed
 
 .Cd configure
+.Cd system capabilities enabled Ar capabilities
+.Bd -ragged -offset XXXXXX
+Override system capabilities with the provided value instead of using
+kernel information. Several capabilities can be specified separated by
+commas. Only available capabilities can be enabled. Valid capabilities are:
+.Bl -tag -width "XXX." -compact -offset XX
+.It Sy other
+.It Sy repeater
+.It Sy bridge
+.It Sy wlan
+.It Sy router
+.It Sy telephone
+.It Sy docsis
+.It Sy station
+.El
+Here is an example of use:
+.D1 configure system capabilities enabled bridge,router
+.Pp
+.Ed
+
+.Cd unconfigure
+.Cd system capabilities enabled
+.Bd -ragged -offset XXXXXX
+Do not override capabilities and use the kernel information. This option
+undoes the previous one.
+.Ed
+
+.Cd configure
 .Cd system interface pattern Ar pattern
 .Bd -ragged -offset XXXXXX
 Specify which interface to listen and send LLDPDU to. Without this

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -351,17 +351,19 @@ interfaces_helper_chassis(struct lldpd *cfg,
 	struct lldpd_hardware *hardware;
 	char *name = NULL;
 
-	LOCAL_CHASSIS(cfg)->c_cap_enabled &=
-			    ~(LLDP_CAP_BRIDGE | LLDP_CAP_WLAN | LLDP_CAP_STATION);
-	TAILQ_FOREACH(iface, interfaces, next) {
-		if (iface->type & IFACE_BRIDGE_T)
-			LOCAL_CHASSIS(cfg)->c_cap_enabled |= LLDP_CAP_BRIDGE;
-		if (iface->type & IFACE_WIRELESS_T)
-			LOCAL_CHASSIS(cfg)->c_cap_enabled |= LLDP_CAP_WLAN;
+	if (!cfg->g_config.c_cap_override) {
+		LOCAL_CHASSIS(cfg)->c_cap_enabled &=
+		    ~(LLDP_CAP_BRIDGE | LLDP_CAP_WLAN | LLDP_CAP_STATION);
+		TAILQ_FOREACH(iface, interfaces, next) {
+			if (iface->type & IFACE_BRIDGE_T)
+				LOCAL_CHASSIS(cfg)->c_cap_enabled |= LLDP_CAP_BRIDGE;
+			if (iface->type & IFACE_WIRELESS_T)
+				LOCAL_CHASSIS(cfg)->c_cap_enabled |= LLDP_CAP_WLAN;
+		}
+		if ((LOCAL_CHASSIS(cfg)->c_cap_available & LLDP_CAP_STATION) &&
+		    (LOCAL_CHASSIS(cfg)->c_cap_enabled == 0))
+			LOCAL_CHASSIS(cfg)->c_cap_enabled = LLDP_CAP_STATION;
 	}
-	if ((LOCAL_CHASSIS(cfg)->c_cap_available & LLDP_CAP_STATION) &&
-		(LOCAL_CHASSIS(cfg)->c_cap_enabled == 0))
-	    LOCAL_CHASSIS(cfg)->c_cap_enabled = LLDP_CAP_STATION;
 
 	/* Do not modify the chassis if it's already set to a MAC address or if
 	 * it's set to a local address equal to the user-provided

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -234,6 +234,8 @@ _lldpctl_atom_get_int_config(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return c->config->c_promisc;
 	case lldpctl_k_config_chassis_cap_advertise:
 		return c->config->c_cap_advertise;
+	case lldpctl_k_config_chassis_cap_override:
+		return c->config->c_cap_override;
 	case lldpctl_k_config_chassis_mgmt_advertise:
 		return c->config->c_mgmt_advertise;
 #ifdef ENABLE_LLDPMED
@@ -284,6 +286,9 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key,
 		break;
 	case lldpctl_k_config_chassis_cap_advertise:
 		config.c_cap_advertise = c->config->c_cap_advertise = value;
+		break;
+	case lldpctl_k_config_chassis_cap_override:
+		config.c_cap_override = c->config->c_cap_override = value;
 		break;
 	case lldpctl_k_config_chassis_mgmt_advertise:
 		config.c_mgmt_advertise = c->config->c_mgmt_advertise = value;

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -718,6 +718,7 @@ typedef enum {
 	lldpctl_k_config_cid_string,    /**< `(S,WON)` User defined string for the chassis ID */
 	lldpctl_k_config_perm_iface_pattern, /**< `(S,WON)` Pattern of permanent interfaces */
 	lldpctl_k_config_tx_interval_ms, /**< `(I,WO)` Transmit interval in milliseconds. Set to -1 to transmit now. */
+	lldpctl_k_config_chassis_cap_override, /**< `(I,WO)` Override chassis capabilities */
 
 	lldpctl_k_interface_name = 1000, /**< `(S)` The interface name. */
 
@@ -793,13 +794,13 @@ typedef enum {
 	lldpctl_k_chassis_id,	      /**< `(BS)` The ID of this chassis. */
 	lldpctl_k_chassis_name,	      /**< `(S)` The name of this chassis. */
 	lldpctl_k_chassis_descr,      /**< `(S)` The description of this chassis. */
-	lldpctl_k_chassis_cap_available, /**< `(I)` Available capabalities (see `LLDP_CAP_*`) */
+	lldpctl_k_chassis_cap_available, /**< `(I)` Available capabilities (see `LLDP_CAP_*`) */
 	lldpctl_k_chassis_cap_enabled,	 /**< `(I)` Enabled capabilities (see `LLDP_CAP_*`) */
 	lldpctl_k_chassis_mgmt,		 /**< `(AL)` List of management addresses */
 	lldpctl_k_chassis_ttl,		 /**< Deprecated */
 
 	lldpctl_k_chassis_med_type = 1900, /**< `(IS)` Chassis MED type. See `LLDP_MED_CLASS_*` */
-	lldpctl_k_chassis_med_cap,  /**< `(I)` Available MED capabilitied. See `LLDP_MED_CAP_*` */
+	lldpctl_k_chassis_med_cap,  /**< `(I)` Available MED capabilities. See `LLDP_MED_CAP_*` */
 	lldpctl_k_chassis_med_inventory_hw, /**< `(S,W)` LLDP MED inventory "Hardware Revision" */
 	lldpctl_k_chassis_med_inventory_sw, /**< `(S,W)` LLDP MED inventory "Software Revision" */
 	lldpctl_k_chassis_med_inventory_fw, /**< `(S,W)` LLDP MED inventory "Firmware Revision" */

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -411,6 +411,7 @@ struct lldpd_config {
 	int c_set_ifdescr;	 /* Set interface description */
 	int c_promisc;		 /* Interfaces should be in promiscuous mode */
 	int c_cap_advertise;	 /* Chassis capabilities advertisement */
+	int c_cap_override;	 /* Override chassis capabilities enabled */
 	int c_mgmt_advertise;	 /* Management addresses advertisement */
 
 #ifdef ENABLE_LLDPMED


### PR DESCRIPTION
Patch in response to [#522](https://github.com/lldpd/lldpd/issues/522#issuecomment-1195935521)

1) configure system capabilities enabled <capability_0,capability_1,...>

    Override system capabilities with the provided value instead of using kernel information. Several capabilities can be specified separated by commas. Only available capabilities can be enabled. Valid capabilities are:

        other
        repeater
        bridge
        wlan
        router
        telephone
        docsis
        station

    Here is an example of use:

        lldpcli configure system capabilities enabled bridge,router

2) unconfigure system capabilities enabled

    Do not override capabilities and use the kernel information. This option undoes the previous one.

Ignacio Sanchez Navarro (Ignacio.Sanchez@uws.ac.uk) - University of the West of Scotland - Supported by H2020-ICT-2020-2/101017226 6G-BRAINS

-------------------------------------------------------------------------------
Modified files

lldpd-structs.h
    - Added new attribute "c_cap_override" to "lldpd_config" struct

conf-system.c
    - Added new function "cmd_capability" for new command to override the chassis capabilities
    - Added new function "register_commands_capabilities" to registers new commands to override the chassis capabilities
    - Added call to "register_commands_capabilities" in "register_commands_configure_system"

chassis.c
    - Added new function "_lldpctl_atom_st_int_chassis" to set "int" type vars in chassis
    - Added assignation of ".set_int" function in "chassis" var build

config.c
    - Added case for "lldpctl_k_config_chassis_cap_override" to get value of "c_cap_override" in "_lldpctl_atom_get_int_config" function
    - Added case for "lldpctl_k_config_chassis_cap_override" to set value of "c_cap_override" in "_lldpctl_atom_set_int_config" function

client.c
    - Added changes check for "c_cap_override" var in "client_handle_set_configuration" function
    - Added changes check for "c_cap_enabled" var in "client_handle_set_local_chassis" function

lldpctl.h
    - Added new enum values un "lldpctl_key_t" enum : "lldpctl_k_chassis_cap_enabled" and "lldpctl_k_config_chassis_cap_override"
    - Corrected some typos in previous comments

lldpd.c
    - Added check of capabilities override before setting new values in "lldpd_update_localchassis" function
    - Added check of capabilities override before setting initial value of "c_cap_enabled" to 0 in "lldpd_loop" function
    - Added initial set of "cfg->g_config.c_cap_override" to 0 in "lldpd_main" function

interfaces.c
    - Added check of capabilities override before setting new values in "interfaces_helper_chassis" function

display.c
    - Added new line to display the status of capabilities override in "show configration" command

lldpcli.8.in
    - Added new commands and descriptions to man file