### PR TITLE
m4/progname.m4: Include <stdio.h> for printf in lldp_CHECK___PROGNAME

### DIFF
--- a/m4/progname.m4
+++ b/m4/progname.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([lldp_CHECK___PROGNAME],[
   AC_CACHE_CHECK([whether libc defines __progname], lldp_cv_check___progname, [
     AC_LINK_IFELSE([AC_LANG_PROGRAM(
-                     [[]],
+                     [[#include<stdio.h>]],
                      [[ extern char *__progname; printf("%s", __progname); ]])],
                      [ lldp_cv_check___progname="yes" ],
                      [ lldp_cv_check___progname="no" ])


### PR DESCRIPTION
Otherwise the checks always fails with a compiler that does not support implict function declarations.

Found as part of:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC