### PR TITLE
[bug] Use-of-uninitialized-value, Integer-overflow

### DIFF
--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -614,7 +614,7 @@ lldp_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardwa
 #endif
 	struct lldpd_mgmt *mgmt;
 	int af;
-	u_int8_t addr_str_length, addr_str_buffer[32];
+	u_int8_t addr_str_length, addr_str_buffer[32] = { 0 };
 	u_int8_t addr_family, addr_length, *addr_ptr, iface_subtype;
 	u_int32_t iface_number, iface;
 	int unrecognized;

--- a/tests/fuzz_edp.c
+++ b/tests/fuzz_edp.c
@@ -32,6 +32,7 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
 	struct lldpd cfg;
 	cfg.g_config.c_mgmt_pattern = NULL;
+	cfg.g_config.c_tx_hold = LLDPD_TX_HOLD;
 
 	struct lldpd_chassis *nchassis = NULL;
 	struct lldpd_port *nport = NULL;


### PR DESCRIPTION
bug : [Use-of-uninitialized-value](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59532&q=proj%3Dlldpd&can=2) [Integer-overflow](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60046&q=proj%3Dlldpd&can=2)
