### PR TITLE
[oss-fuzz] Issue 62435

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -190,7 +190,7 @@ vlog(int pri, const char *token, const char *fmt, va_list ap)
 void
 log_warn(const char *token, const char *emsg, ...)
 {
-	char *nfmt;
+	char *nfmt = NULL;
 	va_list ap;
 
 	/* best effort to even work in out of memory situations */

--- a/tests/fuzz_edp.c
+++ b/tests/fuzz_edp.c
@@ -37,6 +37,7 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	struct lldpd_chassis *nchassis = NULL;
 	struct lldpd_port *nport = NULL;
 	struct lldpd_hardware hardware;
+	TAILQ_INIT(&hardware.h_rports);
 	log_register(donothing);
 
 	edp_decode(&cfg, (char *)Data, Size, &hardware, &nchassis, &nport);


### PR DESCRIPTION
`Use-of-uninitialized-value`  [bug](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62435) fix .
