### PR TITLE
client: translate dot into the short hostname

### DIFF
--- a/src/client/conf-system.c
+++ b/src/client/conf-system.c
@@ -205,6 +205,9 @@ cmd_hostname(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 			lldpctl_atom_dec_ref(config);
 			return 0;
 		}
+		char *c = strchr(un.nodename, '.');
+		if (c)
+			*c = 0;
 		value = un.nodename;
 	}
 	if (lldpctl_atom_set_str(config, lldpctl_k_config_hostname, value) == NULL) {


### PR DESCRIPTION
as documented in lldpcli(8):

    configure system hostname name

        Override system hostname with the provided value. By default, the
        system name is the FQDN found from the resolved value of uname
        -n.  As a special value, use "." (dot) to use the short hostname
        instead of a FQDN.