### PR TITLE
build: improve const correctness and prototype declarations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,7 @@ AX_CFLAGS_GCC_OPTION([-Wheader-guard], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Wdocumentation], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Winline], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Wpointer-arith], [LLDP_CFLAGS])
+AX_CFLAGS_GCC_OPTION([-Wmissing-prototypes], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Wno-cast-align], [LLDP_CFLAGS]) dnl clang is bad at this
 AX_CFLAGS_GCC_OPTION([-Wno-unused-parameter], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Wno-missing-field-initializers], [LLDP_CFLAGS])

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -70,9 +70,10 @@ struct cmd_node;
 struct cmd_env;
 struct cmd_node *commands_root(void);
 struct cmd_node *commands_new(struct cmd_node *, const char *, const char *,
-    int (*validate)(struct cmd_env *, void *),
-    int (*execute)(struct lldpctl_conn_t *, struct writer *, struct cmd_env *, void *),
-    void *);
+    int (*validate)(struct cmd_env *, const void *),
+    int (*execute)(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
+	const void *),
+    const void *);
 struct cmd_node *commands_privileged(struct cmd_node *);
 struct cmd_node *commands_lock(struct cmd_node *);
 struct cmd_node *commands_hidden(struct cmd_node *);
@@ -85,21 +86,23 @@ int commands_execute(struct lldpctl_conn_t *, struct writer *, struct cmd_node *
     const char **, int);
 char *commands_complete(struct cmd_node *, int, const char **, int, int);
 /* helpers */
-int cmd_check_no_env(struct cmd_env *, void *);
-int cmd_check_env(struct cmd_env *, void *);
-int cmd_store_env(struct lldpctl_conn_t *, struct writer *, struct cmd_env *, void *);
+int cmd_check_no_env(struct cmd_env *, const void *);
+int cmd_check_env(struct cmd_env *, const void *);
+int cmd_store_env(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
+    const void *);
 int cmd_store_env_and_pop(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
-    void *);
+    const void *);
 int cmd_store_env_value(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
-    void *);
+    const void *);
 int cmd_store_env_value_and_pop(struct lldpctl_conn_t *, struct writer *,
-    struct cmd_env *, void *);
+    struct cmd_env *, const void *);
 int cmd_store_env_value_and_pop2(struct lldpctl_conn_t *, struct writer *,
-    struct cmd_env *, void *);
+    struct cmd_env *, const void *);
 int cmd_store_env_value_and_pop3(struct lldpctl_conn_t *, struct writer *,
-    struct cmd_env *, void *);
-int cmd_store_something_env_value_and_pop2(const char *, struct cmd_env *, void *);
-int cmd_store_something_env_value(const char *, struct cmd_env *, void *);
+    struct cmd_env *, const void *);
+int cmd_store_something_env_value_and_pop2(const char *, struct cmd_env *,
+    const void *);
+int cmd_store_something_env_value(const char *, struct cmd_env *, const void *);
 lldpctl_atom_t *cmd_iterate_on_interfaces(struct lldpctl_conn_t *, struct cmd_env *);
 lldpctl_atom_t *cmd_iterate_on_ports(struct lldpctl_conn_t *, struct cmd_env *,
     const char **);
@@ -108,7 +111,7 @@ void cmd_restrict_protocol(struct cmd_node *);
 
 /* misc.c */
 int contains(const char *, const char *);
-char *totag(const char *);
+const char *totag(const char *);
 
 /* display.c */
 #define DISPLAY_BRIEF 1

--- a/src/client/commands.c
+++ b/src/client/commands.c
@@ -80,15 +80,15 @@ struct cmd_node {
 	/**
 	 * Function validating entry in this node. Can be @c NULL.
 	 */
-	int (*validate)(struct cmd_env *, void *);
+	int (*validate)(struct cmd_env *, const void *);
 	/**
 	 * Function to execute when entering this node. May be @c NULL.
 	 *
 	 * This function can alter the environment
 	 */
 	int (*execute)(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
-	    void *);
-	void *arg; /**< Magic argument for the previous two functions */
+	    const void *);
+	const void *arg; /**< Magic argument for the previous two functions */
 
 	/* List of possible subentries */
 	TAILQ_HEAD(, cmd_node) subentries; /* List of subnodes */
@@ -166,9 +166,10 @@ commands_hidden(struct cmd_node *node)
  */
 struct cmd_node *
 commands_new(struct cmd_node *root, const char *token, const char *doc,
-    int (*validate)(struct cmd_env *, void *),
-    int (*execute)(struct lldpctl_conn_t *, struct writer *, struct cmd_env *, void *),
-    void *arg)
+    int (*validate)(struct cmd_env *, const void *),
+    int (*execute)(struct lldpctl_conn_t *, struct writer *, struct cmd_env *,
+	const void *),
+    const void *arg)
 {
 	struct cmd_node *new = calloc(1, sizeof(struct cmd_node));
 	if (new == NULL) fatalx("lldpctl", "out of memory");
@@ -619,7 +620,7 @@ commands_execute(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_node 
  * @return 1 if the environment does not contain the key. 0 otherwise.
  */
 int
-cmd_check_no_env(struct cmd_env *env, void *key)
+cmd_check_no_env(struct cmd_env *env, const void *key)
 {
 	return cmdenv_get(env, (const char *)key) == NULL;
 }
@@ -632,7 +633,7 @@ cmd_check_no_env(struct cmd_env *env, void *key)
  * @return 1 if the environment does contain the key. 0 otherwise.
  */
 int
-cmd_check_env(struct cmd_env *env, void *key)
+cmd_check_env(struct cmd_env *env, const void *key)
 {
 	struct cmd_env_el *el;
 	const char *list = key;
@@ -658,7 +659,7 @@ cmd_check_env(struct cmd_env *env, void *key)
  */
 int
 cmd_store_env(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *key)
+    const void *key)
 {
 	return cmdenv_put(env, key, NULL) != -1;
 }
@@ -674,7 +675,7 @@ cmd_store_env(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env
  */
 int
 cmd_store_env_and_pop(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *key)
+    struct cmd_env *env, const void *key)
 {
 	return (cmd_store_env(conn, w, env, key) != -1 && cmdenv_pop(env, 1) != -1);
 }
@@ -691,39 +692,39 @@ cmd_store_env_and_pop(struct lldpctl_conn_t *conn, struct writer *w,
  */
 int
 cmd_store_env_value_and_pop(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *key)
+    struct cmd_env *env, const void *key)
 {
 	return (
 	    cmdenv_put(env, key, cmdenv_arg(env)) != -1 && cmdenv_pop(env, 1) != -1);
 }
 int
 cmd_store_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *key)
+    struct cmd_env *env, const void *key)
 {
 	return (
 	    cmdenv_put(env, key, cmdenv_arg(env)) != -1 && cmdenv_pop(env, 2) != -1);
 }
 int
 cmd_store_env_value(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *key)
+    const void *key)
 {
 	return (cmdenv_put(env, key, cmdenv_arg(env)) != -1);
 }
 int
 cmd_store_env_value_and_pop3(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *key)
+    struct cmd_env *env, const void *key)
 {
 	return (
 	    cmdenv_put(env, key, cmdenv_arg(env)) != -1 && cmdenv_pop(env, 3) != -1);
 }
 int
 cmd_store_something_env_value_and_pop2(const char *what, struct cmd_env *env,
-    void *value)
+    const void *value)
 {
 	return (cmdenv_put(env, what, value) != -1 && cmdenv_pop(env, 2) != -1);
 }
 int
-cmd_store_something_env_value(const char *what, struct cmd_env *env, void *value)
+cmd_store_something_env_value(const char *what, struct cmd_env *env, const void *value)
 {
 	return (cmdenv_put(env, what, value) != -1);
 }

--- a/src/client/conf-inv.c
+++ b/src/client/conf-inv.c
@@ -12,7 +12,7 @@
 
 static int
 cmd_inventory(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "configure inventory information");
 
@@ -24,7 +24,7 @@ cmd_inventory(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env
 		return 0;
 	}
 
-	char *action = arg;
+	const char *action = arg;
 	if ((!strcmp(action, "hardware-revision") &&
 		(lldpctl_atom_set_str(chassis, lldpctl_k_chassis_med_inventory_hw,
 		     cmdenv_get(env, "hardware-revision")) == NULL)) ||

--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -24,7 +24,7 @@
 
 static int
 cmd_txdelay(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	const char *interval;
 	char interval_ms[8]; /* less than 2.5 hours */
@@ -68,7 +68,7 @@ cmd_txdelay(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 
 static int
 cmd_txhold(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set transmit hold");
 
@@ -93,7 +93,7 @@ cmd_txhold(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 
 static int
 cmd_status(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	lldpctl_atom_t *port;
 	const char *name;
@@ -120,7 +120,7 @@ cmd_status(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 
 static int
 cmd_agent_type(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	const char *str = arg;
 	int value = -1;
@@ -167,7 +167,7 @@ cmd_agent_type(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *en
 
 static int
 cmd_portid_type_local(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	lldpctl_atom_t *port;
 	const char *name;
@@ -203,7 +203,7 @@ cmd_portid_type_local(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_port_descr(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	lldpctl_atom_t *port;
 	const char *name;
@@ -226,9 +226,9 @@ cmd_port_descr(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *en
 
 static int
 cmd_portid_type(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
-	char *value_str;
+	const char *value_str = 0;
 	int value = -1;
 
 	log_debug("lldpctl", "lldp PortID TLV Subtype");
@@ -274,7 +274,7 @@ cmd_portid_type(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *e
 
 static int
 cmd_chassis_cap_advertise(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "lldp capabilities-advertisements %s",
 	    arg ? "enable" : "disable");
@@ -302,7 +302,7 @@ cmd_chassis_cap_advertise(struct lldpctl_conn_t *conn, struct writer *w,
 /* FIXME: see about compressing this with other functions */
 static int
 cmd_chassis_mgmt_advertise(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "lldp management-addresses-advertisements %s",
 	    arg ? "enable" : "disable");
@@ -329,7 +329,7 @@ cmd_chassis_mgmt_advertise(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_vlan_tx(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	lldpctl_atom_t *port;
 	const char *name;
@@ -416,7 +416,7 @@ cmd_vlan_tx(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 #ifdef ENABLE_CUSTOM
 static int
 cmd_custom_tlv_set(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	lldpctl_atom_t *port;
 	const char *s;
@@ -425,7 +425,7 @@ cmd_custom_tlv_set(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env
 	uint8_t oui_info[LLDP_TLV_ORG_OUI_INFO_MAXLEN];
 	int oui_info_len = 0;
 	uint16_t subtype = 0;
-	char *op = "add";
+	const char *op = "add";
 
 	if (!arg || !strcmp(arg, "remove")) op = "remove";
 
@@ -514,7 +514,7 @@ set:
 }
 
 static int
-cmd_check_no_add_env(struct cmd_env *env, void *arg)
+cmd_check_no_add_env(struct cmd_env *env, const void *arg)
 {
 	const char *what = arg;
 	if (cmdenv_get(env, "add")) return 0;
@@ -523,7 +523,7 @@ cmd_check_no_add_env(struct cmd_env *env, void *arg)
 }
 
 static int
-cmd_check_no_replace_env(struct cmd_env *env, void *arg)
+cmd_check_no_replace_env(struct cmd_env *env, const void *arg)
 {
 	const char *what = arg;
 	if (cmdenv_get(env, "replace")) return 0;
@@ -531,7 +531,7 @@ cmd_check_no_replace_env(struct cmd_env *env, void *arg)
 	return 1;
 }
 
-void
+static void
 register_commands_configure_lldp_custom_tlvs(struct cmd_node *configure_lldp,
     struct cmd_node *unconfigure_lldp)
 {
@@ -597,7 +597,7 @@ register_commands_configure_lldp_custom_tlvs(struct cmd_node *configure_lldp,
 
 static int
 cmd_store_status_env_value(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value("status", env, value);
 }

--- a/src/client/conf-med.c
+++ b/src/client/conf-med.c
@@ -151,7 +151,7 @@ _cmd_medlocation(struct lldpctl_conn_t *conn, struct cmd_env *env, int format)
 
 static int
 cmd_medlocation_coordinate(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "set MED location coordinate");
 	return _cmd_medlocation(conn, env, LLDP_MED_LOCFORMAT_COORD);
@@ -159,7 +159,7 @@ cmd_medlocation_coordinate(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_medlocation_address(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "set MED location address");
 	return _cmd_medlocation(conn, env, LLDP_MED_LOCFORMAT_CIVIC);
@@ -167,7 +167,7 @@ cmd_medlocation_address(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_medlocation_elin(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set MED location ELIN");
 	return _cmd_medlocation(conn, env, LLDP_MED_LOCFORMAT_ELIN);
@@ -175,7 +175,7 @@ cmd_medlocation_elin(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_e
 
 static int
 cmd_medpolicy(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set MED policy");
 	lldpctl_atom_t *iface;
@@ -347,7 +347,7 @@ register_commands_medloc(struct cmd_node *configure_med)
 }
 
 static int
-cmd_check_application_but_no(struct cmd_env *env, void *arg)
+cmd_check_application_but_no(struct cmd_env *env, const void *arg)
 {
 	const char *what = arg;
 	if (!cmdenv_get(env, "application")) return 0;
@@ -356,13 +356,13 @@ cmd_check_application_but_no(struct cmd_env *env, void *arg)
 }
 static int
 cmd_store_app_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value_and_pop2("application", env, value);
 }
 static int
 cmd_store_prio_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value_and_pop2("priority", env, value);
 }
@@ -418,7 +418,7 @@ register_commands_medpol(struct cmd_node *configure_med)
 
 static int
 cmd_faststart(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "configure fast interval support");
 
@@ -429,7 +429,7 @@ cmd_faststart(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env
 		return 0;
 	}
 
-	char *action = arg;
+	const char *action = arg;
 	if ((!strcmp(action, "enable") &&
 		(lldpctl_atom_set_int(config, lldpctl_k_config_fast_start_enabled, 1) ==
 		    NULL)) ||

--- a/src/client/conf-power.c
+++ b/src/client/conf-power.c
@@ -23,7 +23,7 @@
 
 static int
 cmd_medpower(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set MED power");
 	lldpctl_atom_t *port;
@@ -72,26 +72,26 @@ cmd_medpower(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 
 static int
 cmd_store_powerpairs_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value_and_pop2("powerpairs", env, value);
 }
 static int
 cmd_store_class_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value_and_pop2("class", env, value);
 }
 static int
 cmd_store_prio_env_value_and_pop2(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *value)
+    struct cmd_env *env, const void *value)
 {
 	return cmd_store_something_env_value_and_pop2("priority", env, value);
 }
 
 static int
 cmd_dot3power(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set dot3 power");
 	lldpctl_atom_t *port;
@@ -196,7 +196,7 @@ cmd_dot3power(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env
 }
 
 static int
-cmd_check_type_but_no(struct cmd_env *env, void *arg)
+cmd_check_type_but_no(struct cmd_env *env, const void *arg)
 {
 	const char *what = arg;
 	if (!cmdenv_get(env, "device-type")) return 0;
@@ -204,7 +204,7 @@ cmd_check_type_but_no(struct cmd_env *env, void *arg)
 	return 1;
 }
 static int
-cmd_check_typeat_but_no(struct cmd_env *env, void *arg)
+cmd_check_typeat_but_no(struct cmd_env *env, const void *arg)
 {
 	const char *what = arg;
 	if (!cmdenv_get(env, "typeat")) return 0;
@@ -219,12 +219,12 @@ cmd_check_type(struct cmd_env *env, const char *type)
 	return (!strcmp(type, etype));
 }
 static int
-cmd_check_pse(struct cmd_env *env, void *arg)
+cmd_check_pse(struct cmd_env *env, const void *arg)
 {
 	return cmd_check_type(env, "pse");
 }
 static int
-cmd_check_pd(struct cmd_env *env, void *arg)
+cmd_check_pd(struct cmd_env *env, const void *arg)
 {
 	return cmd_check_type(env, "pd");
 }
@@ -294,7 +294,7 @@ register_commands_medpow(struct cmd_node *configure_med)
 }
 
 static int
-cmd_check_env_power(struct cmd_env *env, void *nothing)
+cmd_check_env_power(struct cmd_env *env, const void *nothing)
 {
 	/* We need type and powerpair but if we have typeat, we also request
 	 * source, priority, requested and allocated. */

--- a/src/client/conf-system.c
+++ b/src/client/conf-system.c
@@ -24,7 +24,7 @@
 
 static int
 cmd_iface_pattern(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set iface pattern");
 
@@ -51,7 +51,7 @@ cmd_iface_pattern(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env 
 
 static int
 cmd_perm_iface_pattern(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "set permanent iface pattern");
 
@@ -78,7 +78,7 @@ cmd_perm_iface_pattern(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_iface_promisc(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	lldpctl_atom_t *config = lldpctl_get_configuration(conn);
 	if (config == NULL) {
@@ -101,7 +101,7 @@ cmd_iface_promisc(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env 
 
 static int
 cmd_system_description(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	int platform = 0;
 	const char *what = arg;
@@ -135,7 +135,7 @@ cmd_system_description(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_system_chassisid(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	const char *value;
 	value = cmdenv_get(env, "description");
@@ -159,7 +159,7 @@ cmd_system_chassisid(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_e
 
 static int
 cmd_management(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set management pattern");
 
@@ -186,7 +186,7 @@ cmd_management(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *en
 
 static int
 cmd_hostname(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	struct utsname un;
 	log_debug("lldpctl", "set system name");
@@ -223,7 +223,7 @@ cmd_hostname(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
 
 static int
 cmd_capability(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set capabilities");
 
@@ -312,7 +312,7 @@ cmd_capability_end:
 
 static int
 cmd_update_descriptions(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	lldpctl_atom_t *config = lldpctl_get_configuration(conn);
 	if (config == NULL) {
@@ -335,9 +335,9 @@ cmd_update_descriptions(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_bondslave_srcmac_type(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
-	char *value_str;
+	const char *value_str = 0;
 	int value = -1;
 
 	log_debug("lldpctl", "bond slave src mac");
@@ -383,7 +383,7 @@ cmd_bondslave_srcmac_type(struct lldpctl_conn_t *conn, struct writer *w,
 
 static int
 cmd_maxneighs(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "set maximum neighbors");
 

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -31,7 +31,7 @@
 #include "client.h"
 
 static void
-display_cap(struct writer *w, lldpctl_atom_t *chassis, u_int8_t bit, char *symbol)
+display_cap(struct writer *w, lldpctl_atom_t *chassis, u_int8_t bit, const char *symbol)
 {
 	if (lldpctl_atom_get_int(chassis, lldpctl_k_chassis_cap_available) & bit) {
 		tag_start(w, "capability", "Capability");
@@ -329,7 +329,8 @@ display_custom_tlvs(struct writer *w, lldpctl_atom_t *neighbor)
 }
 
 static void
-display_autoneg(struct writer *w, int advertised, int bithd, int bitfd, char *desc)
+display_autoneg(struct writer *w, int advertised, int bithd, int bitfd,
+    const char *desc)
 {
 	if (!((advertised & bithd) || (advertised & bitfd))) return;
 
@@ -839,7 +840,7 @@ display_local_interfaces(lldpctl_conn_t *conn, struct writer *w, struct cmd_env 
 	tag_end(w);
 }
 
-void
+static void
 display_stat(struct writer *w, const char *tag, const char *descr,
     long unsigned int cnt)
 {

--- a/src/client/kv_writer.c
+++ b/src/client/kv_writer.c
@@ -30,7 +30,7 @@ struct kv_writer_private {
 	char *prefix;
 };
 
-void
+static void
 kv_start(struct writer *w, const char *tag, const char *descr)
 {
 	struct kv_writer_private *p = w->priv;
@@ -47,7 +47,7 @@ kv_start(struct writer *w, const char *tag, const char *descr)
 	p->prefix = newprefix;
 }
 
-void
+static void
 kv_data(struct writer *w, const char *data)
 {
 	struct kv_writer_private *p = w->priv;
@@ -69,7 +69,7 @@ kv_data(struct writer *w, const char *data)
 	free(value);
 }
 
-void
+static void
 kv_end(struct writer *w)
 {
 	struct kv_writer_private *p = w->priv;
@@ -82,7 +82,7 @@ kv_end(struct writer *w)
 		*dot = '\0';
 }
 
-void
+static void
 kv_attr(struct writer *w, const char *tag, const char *descr, const char *value)
 {
 	if (!strcmp(tag, "name") || !strcmp(tag, "type")) {
@@ -96,7 +96,7 @@ kv_attr(struct writer *w, const char *tag, const char *descr, const char *value)
 	}
 }
 
-void
+static void
 kv_finish(struct writer *w)
 {
 	struct kv_writer_private *p = w->priv;

--- a/src/client/lldpcli.c
+++ b/src/client/lldpcli.c
@@ -92,7 +92,7 @@ is_privileged()
 	return (ctlname && access(ctlname, R_OK | W_OK) == 0);
 }
 
-static char *
+static const char *
 prompt()
 {
 #define CESC "\033"
@@ -109,7 +109,8 @@ static int must_exit = 0;
  * Exit the interpreter.
  */
 static int
-cmd_exit(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env, void *arg)
+cmd_exit(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
+    const void *arg)
 {
 	log_info("lldpctl", "quit lldpcli");
 	must_exit = 1;
@@ -121,7 +122,7 @@ cmd_exit(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env, voi
  */
 static int
 cmd_update(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_info("lldpctl", "ask for global update");
 
@@ -176,7 +177,8 @@ cmd_pause_resume(lldpctl_conn_t *conn, int pause)
 	return 1;
 }
 static int
-cmd_pause(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env, void *arg)
+cmd_pause(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
+    const void *arg)
 {
 	(void)w;
 	(void)env;
@@ -184,7 +186,7 @@ cmd_pause(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env, vo
 }
 static int
 cmd_resume(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	(void)w;
 	(void)env;

--- a/src/client/misc.c
+++ b/src/client/misc.c
@@ -49,7 +49,7 @@ contains(const char *list, const char *element)
  * @param value String to transform to a tag.
  * @return The tagged value or the string "none" if @c value is @c NULL
  */
-char *
+const char *
 totag(const char *value)
 {
 	int i;

--- a/src/client/show.c
+++ b/src/client/show.c
@@ -30,7 +30,7 @@
  */
 static int
 cmd_show_neighbors(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "show neighbors data (%s) %s hidden neighbors",
 	    cmdenv_get(env, "summary")	    ? "summary" :
@@ -60,7 +60,7 @@ cmd_show_neighbors(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env
  */
 static int
 cmd_show_interfaces(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "show interfaces data (%s) %s hidden interfaces",
 	    cmdenv_get(env, "summary")	    ? "summary" :
@@ -88,7 +88,7 @@ cmd_show_interfaces(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_en
  */
 static int
 cmd_show_chassis(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	log_debug("lldpctl", "show chassis data (%s)",
 	    cmdenv_get(env, "summary")	    ? "summary" :
@@ -112,7 +112,7 @@ cmd_show_chassis(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *
  */
 static int
 cmd_show_interface_stats(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "show stats data");
 	if (cmdenv_get(env, "ports"))
@@ -127,7 +127,7 @@ cmd_show_interface_stats(struct lldpctl_conn_t *conn, struct writer *w,
 }
 
 static int
-cmd_check_no_detailed_nor_summary(struct cmd_env *env, void *arg)
+cmd_check_no_detailed_nor_summary(struct cmd_env *env, const void *arg)
 {
 	if (cmdenv_get(env, "detailed")) return 0;
 	if (cmdenv_get(env, "summary")) return 0;
@@ -139,7 +139,7 @@ cmd_check_no_detailed_nor_summary(struct cmd_env *env, void *arg)
  */
 static int
 cmd_show_configuration(struct lldpctl_conn_t *conn, struct writer *w,
-    struct cmd_env *env, void *arg)
+    struct cmd_env *env, const void *arg)
 {
 	log_debug("lldpctl", "show running configuration");
 	display_configuration(conn, w);
@@ -215,7 +215,7 @@ watchcb(lldpctl_change_t type, lldpctl_atom_t *interface, lldpctl_atom_t *neighb
  */
 static int
 cmd_watch_neighbors(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    void *arg)
+    const void *arg)
 {
 	struct watcharg wa = { .env = env, .w = w, .nb = 0 };
 	const char *limit_str = cmdenv_get(env, "limit");
@@ -250,7 +250,7 @@ cmd_watch_neighbors(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_en
 /**
  * Register common subcommands for `watch` and `show neighbors` and `show chassis'
  */
-void
+static void
 register_common_commands(struct cmd_node *root, int neighbor)
 {
 	/* With more details */
@@ -277,7 +277,7 @@ register_common_commands(struct cmd_node *root, int neighbor)
 /**
  * Register sub command summary
  */
-void
+static void
 register_summary_command(struct cmd_node *root)
 {
 	commands_new(root, "summary", "With less details",

--- a/src/client/tokenizer.c
+++ b/src/client/tokenizer.c
@@ -32,9 +32,9 @@ tokenize_line(const char *line, int *argc, char ***argv)
 {
 	int iargc = 0;
 	char **iargv = NULL;
-	char *ifs = " \n\t";
-	char *quotes = "'\"";
-	char *escapes = "\\";
+	const char ifs[] = " \n\t";
+	const char quotes[] = "'\"";
+	const char escapes[] = "\\";
 	char empty = 2; /* Empty character, will be removed from output
 			 * but will mark a word. */
 

--- a/src/client/utf8.c
+++ b/src/client/utf8.c
@@ -22,6 +22,7 @@
 */
 
 #include <stddef.h>
+#include "writer.h"
 
 /*
  * Validate a single UTF-8 character starting at @s.

--- a/src/client/writer.h
+++ b/src/client/writer.h
@@ -19,6 +19,7 @@
 #define _WRITER_H
 
 #include <stdio.h>
+#include <config.h>
 
 struct writer {
 	void *priv;

--- a/src/client/xml_writer.c
+++ b/src/client/xml_writer.c
@@ -39,7 +39,7 @@ struct xml_writer_private {
 	xmlDocPtr doc;
 };
 
-void
+static void
 xml_new_writer(struct xml_writer_private *priv)
 {
 	priv->xw = xmlNewTextWriterDoc(&(priv->doc), 0);
@@ -51,7 +51,7 @@ xml_new_writer(struct xml_writer_private *priv)
 		fatalx("lldpctl", "cannot start xml document");
 }
 
-void
+static void
 xml_start(struct writer *w, const char *tag, const char *descr)
 {
 	struct xml_writer_private *p = w->priv;
@@ -71,7 +71,7 @@ xml_start(struct writer *w, const char *tag, const char *descr)
 	p->depth++;
 }
 
-void
+static void
 xml_attr(struct writer *w, const char *tag, const char *descr, const char *value)
 {
 	struct xml_writer_private *p = w->priv;
@@ -82,7 +82,7 @@ xml_attr(struct writer *w, const char *tag, const char *descr, const char *value
 		    value ? value : "(none)");
 }
 
-void
+static void
 xml_data(struct writer *w, const char *data)
 {
 	struct xml_writer_private *p = w->priv;
@@ -91,7 +91,7 @@ xml_data(struct writer *w, const char *data)
 		    data ? data : "(none)");
 }
 
-void
+static void
 xml_end(struct writer *w)
 {
 	struct xml_writer_private *p = w->priv;
@@ -116,7 +116,7 @@ xml_end(struct writer *w)
 	}
 }
 
-void
+static void
 xml_finish(struct writer *w)
 {
 	struct xml_writer_private *p = w->priv;

--- a/src/daemon/agent.c
+++ b/src/daemon/agent.c
@@ -122,7 +122,7 @@ header_index_add(oid *index, size_t len, void *entity)
 	return 0; /* No best match yet. */
 }
 
-void *
+static void *
 header_index_best()
 {
 	if (header_idx.entity == NULL) return NULL;

--- a/src/daemon/agent_priv.c
+++ b/src/daemon/agent_priv.c
@@ -200,7 +200,7 @@ agent_priv_unix_transport(const char *string, int len, int local)
 }
 
 #  if HAVE_NETSNMP_TDOMAIN_F_CREATE_FROM_TSTRING_NEW
-netsnmp_transport *
+static netsnmp_transport *
 agent_priv_unix_create_tstring_new(const char *string, int local,
     const char *default_target)
 {
@@ -211,7 +211,7 @@ agent_priv_unix_create_tstring_new(const char *string, int local,
 	return agent_priv_unix_transport(string, strlen(string), local);
 }
 #  else
-netsnmp_transport *
+static netsnmp_transport *
 agent_priv_unix_create_tstring(const char *string, int local)
 {
 	if (!string) return NULL;

--- a/src/daemon/dmi-linux.c
+++ b/src/daemon/dmi-linux.c
@@ -30,7 +30,7 @@
 */
 
 static char *
-dmi_get(char *file)
+dmi_get(const char *file)
 {
 	int dmi, s;
 	char buffer[100] = {};

--- a/src/daemon/dmi-openbsd.c
+++ b/src/daemon/dmi-openbsd.c
@@ -21,7 +21,7 @@
 
 #ifdef ENABLE_LLDPMED
 
-char *
+static char *
 dmi_get(int what, const char *descr)
 {
 	char result[100] = {};

--- a/src/daemon/forward-linux.c
+++ b/src/daemon/forward-linux.c
@@ -19,11 +19,11 @@
 
 #include <unistd.h>
 
-int
+static int
 ip_forwarding_enabled(int af)
 {
 	int fd, rc = -1;
-	char *fname;
+	const char *fname;
 	char status;
 
 	if (af == LLDPD_AF_IPV4)

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -759,7 +759,8 @@ static char *
 lldpd_get_lsb_release()
 {
 	static char release[1024];
-	char *const command[] = { "lsb_release", "-s", "-d", NULL };
+	char cmd[][12] = { "lsb_release", "-s", "-d" };
+	char *const command[] = { cmd[0], cmd[1], cmd[2], NULL };
 	int pid, status, devnull, count;
 	int pipefd[2];
 
@@ -1467,7 +1468,8 @@ lldpd_started_by_systemd()
 	strlcpy(su.sun_path, notifysocket, sizeof(su.sun_path));
 	if (notifysocket[0] == '@') su.sun_path[0] = 0;
 
-	struct iovec iov = { .iov_base = "READY=1", .iov_len = strlen("READY=1") };
+	char ready[] = "READY=1";
+	struct iovec iov = { .iov_base = ready, .iov_len = sizeof ready - 1 };
 	struct msghdr hdr = { .msg_name = &su,
 		.msg_namelen =
 		    offsetof(struct sockaddr_un, sun_path) + strlen(notifysocket),

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -85,7 +85,7 @@ struct event_base;
 struct protocol {
 	int mode;			 /* > 0 mode identifier (unique per protocol) */
 	int enabled;			 /* Is this protocol enabled? */
-	char *name;			 /* Name of protocol */
+	const char *name;		 /* Name of protocol */
 	char arg;			 /* Argument to enable this protocol */
 	int (*send)(PROTO_SEND_SIG);	 /* How to send a frame */
 	int (*decode)(PROTO_DECODE_SIG); /* How to decode a frame */
@@ -201,7 +201,7 @@ void priv_wait(void);
 void priv_ctl_cleanup(const char *ctlname);
 char *priv_gethostname(void);
 #ifdef HOST_OS_LINUX
-int priv_open(char *);
+int priv_open(const char *);
 void asroot_open(void);
 #endif
 int priv_iface_init(int, char *);

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -495,7 +495,7 @@ netlink_parse_address(struct nlmsghdr *msg, struct interfaces_address *ifa)
  * Some properties may be absent in the new interface that should be copied over
  * from the old one.
  */
-void
+static void
 netlink_merge(struct interfaces_device *old, struct interfaces_device *new)
 {
 	if (new->alias == NULL) {

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -46,7 +46,7 @@
 
 /* Proxy for open */
 int
-priv_open(char *file)
+priv_open(const char *file)
 {
 	int len, rc;
 	enum priv_cmd cmd = PRIV_OPEN;

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -632,29 +632,30 @@ sig_chld(int sig)
 
 #endif
 
-void
+#ifdef ENABLE_PRIVSEP
+static void
 priv_drop(uid_t uid, gid_t gid)
 {
 	gid_t gidset[1];
 	gidset[0] = gid;
 	log_debug("privsep", "dropping privileges");
-#ifdef HAVE_SETRESGID
+#  ifdef HAVE_SETRESGID
 	if (setresgid(gid, gid, gid) == -1) fatal("privsep", "setresgid() failed");
-#else
+#  else
 	if (setregid(gid, gid) == -1) fatal("privsep", "setregid() failed");
-#endif
+#  endif
 	if (setgroups(1, gidset) == -1) fatal("privsep", "setgroups() failed");
-#ifdef HAVE_SETRESUID
+#  ifdef HAVE_SETRESUID
 	if (setresuid(uid, uid, uid) == -1) fatal("privsep", "setresuid() failed");
-#else
+#  else
 	if (setreuid(uid, uid) == -1) fatal("privsep", "setreuid() failed");
-#endif
+#  endif
 }
 
-void
+static void
 priv_caps(uid_t uid, gid_t gid)
 {
-#ifdef HAVE_LINUX_CAPABILITIES
+#  ifdef HAVE_LINUX_CAPABILITIES
 	cap_t caps;
 	const char *caps_strings[2] = {
 		"cap_dac_override,cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe",
@@ -682,10 +683,11 @@ priv_caps(uid_t uid, gid_t gid)
 	if (cap_set_proc(caps) == -1)
 		fatal("privsep", "unable to drop extra privileges");
 	cap_free(caps);
-#else
+#  else
 	log_info("privsep", "no libcap support, running monitor as root");
-#endif
+#  endif
 }
+#endif
 
 void
 #ifdef ENABLE_PRIVSEP

--- a/src/daemon/protocols/cdp.c
+++ b/src/daemon/protocols/cdp.c
@@ -47,7 +47,7 @@ cdp_send(struct lldpd *global, struct lldpd_hardware *hardware, int version)
 	u_int8_t mcastaddr[] = CDP_MULTICAST_ADDR;
 	u_int8_t llcorg[] = LLC_ORG_CISCO;
 #  ifdef ENABLE_FDP
-	char *capstr;
+	const char *capstr;
 #  endif
 	u_int16_t checksum;
 	int length, i;

--- a/src/daemon/protocols/edp.c
+++ b/src/daemon/protocols/edp.c
@@ -46,8 +46,8 @@ edp_send(struct lldpd *global, struct lldpd_hardware *hardware)
 	/* Subsequent XXX can be replaced by other values. We place
 	   them here to ensure the position of "" to be a bit
 	   invariant with version changes. */
-	char *deviceslot[] = { "eth", "veth", "XXX", "XXX", "XXX", "XXX", "XXX", "XXX",
-		"", NULL };
+	const char *deviceslot[] = { "eth", "veth", "XXX", "XXX", "XXX", "XXX", "XXX",
+		"XXX", "", NULL };
 
 	log_debug("edp", "send EDP frame on port %s", hardware->h_ifname);
 

--- a/src/daemon/protocols/sonmp.h
+++ b/src/daemon/protocols/sonmp.h
@@ -32,7 +32,7 @@
 
 struct sonmp_chassis {
 	int type;
-	char *description;
+	const char *description;
 };
 
 #define SONMP_TOPOLOGY_CHANGED 1

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -23,22 +23,24 @@ atom-glue.c: $(ATOM_FILES) Makefile
 	$(AM_V_GEN)(for f in $(ATOM_FILES:%=$(srcdir)/%); do \
 		$(CPP) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 		$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $$f; done | \
-		$(SED) -n 's+^void init_atom_builder_\([^(]*\)().*, \([0-9]*\)).*+\2 \1+p' | \
+		$(SED) -n 's+^void init_atom_builder_\([^(]*\)(void).*, \([0-9]*\)).*+\2 \1+p' | \
 		sort | \
 		$(AWK) '{ atoms[$$2] = 1 } \
 			 END { for (atom in atoms) { print "void init_atom_builder_"atom"(void);" } \
-			       print "void init_atom_builder() {"; \
+			       print "void init_atom_builder(void);"; \
+			       print "void init_atom_builder(void) {"; \
                                print " static int init = 0; if (init) return; init++;"; \
 			       for (atom in atoms) { print " init_atom_builder_"atom"();" } \
 			       print "}"; }' && \
 		for f in $(ATOM_FILES:%=$(srcdir)/%); do \
 		$(CPP) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 		$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $$f; done | \
-		$(SED) -n 's+^void init_atom_map_\([^(]*\)().*, \([0-9]*\)).*+\2 \1+p' | \
+		$(SED) -n 's+^void init_atom_map_\([^(]*\)(void).*, \([0-9]*\)).*+\2 \1+p' | \
 		sort -n | \
 		$(AWK) '{ atoms[$$2] = 1 } \
 			 END { for (atom in atoms) { print "void init_atom_map_"atom"(void);" } \
-			       print "void init_atom_map() {"; \
+			       print "void init_atom_map(void);"; \
+			       print "void init_atom_map(void) {"; \
                                print " static int init = 0; if (init) return; init++;"; \
 			       for (atom in atoms) { print " init_atom_map_"atom"();" } \
 			       print "}"; }' ) \

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -298,7 +298,8 @@ void atom_map_register(struct atom_map *map, int);
 void init_atom_map(void);
 
 #define ATOM_MAP_REGISTER(NAME, PRIO) \
-  void init_atom_map_##NAME()         \
+  void init_atom_map_##NAME(void);    \
+  void init_atom_map_##NAME(void)     \
   {                                   \
     atom_map_register(&NAME, PRIO);   \
   }
@@ -336,7 +337,8 @@ void atom_builder_register(struct atom_builder *builder, int);
 void init_atom_builder(void);
 
 #define ATOM_BUILDER_REGISTER(NAME, PRIO) \
-  void init_atom_builder_##NAME()         \
+  void init_atom_builder_##NAME(void);    \
+  void init_atom_builder_##NAME(void)     \
   {                                       \
     atom_builder_register(&NAME, PRIO);   \
   }

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -587,7 +587,8 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key,
 		return NULL;
 	}
 
-	set.ifname = hardware ? hardware->h_ifname : "";
+	char empty_str[] = "";
+	set.ifname = hardware ? hardware->h_ifname : empty_str;
 
 	if (asprintf(&canary, "%d%p%s", key, value, set.ifname) == -1) {
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOMEM);

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -413,7 +413,7 @@ typedef struct lldpctl_atom_t lldpctl_atom_t;
  */
 typedef const struct {
 	int value;
-	char *string;
+	const char *string;
 } lldpctl_map_t;
 
 /**

--- a/src/log.c
+++ b/src/log.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include "log.h"
 
 /* By default, logging is done on stderr. */
 static int use_syslog = 0;

--- a/src/marshal.h
+++ b/src/marshal.h
@@ -41,8 +41,8 @@ struct marshal_subinfo {
     .offset = 0, .offset2 = 0, .kind = ignore, .mi = NULL \
   }
 struct marshal_info {
-	char *name;  /* Name of structure */
-	size_t size; /* Size of the structure */
+	const char *name; /* Name of structure */
+	size_t size;	  /* Size of the structure */
 #if defined __GNUC__ && __GNUC__ < 3
 	/* With gcc 2.96, flexible arrays are not supported, even with
 	 * -std=gnu99. And with gcc 3.x, zero-sized arrays cannot be statically
@@ -61,19 +61,21 @@ extern struct marshal_info marshal_info_ignore;
    marshal. The marshalled type has to be a structure. */
 #define MARSHAL_INFO(type) marshal_info_##type
 #ifdef MARSHAL_EXPORT
-#  define MARSHAL_HELPER_FUNCTIONS(type, ttype)                              \
-    ssize_t type##_serialize(ttype *source, void *buffer)                    \
-    {                                                                        \
-      return marshal_serialize(type, source, buffer);                        \
-    }                                                                        \
-    size_t type##_unserialize(void *buffer, size_t len, ttype **destination) \
-    {                                                                        \
-      void *p;                                                               \
-      size_t rc;                                                             \
-      rc = marshal_unserialize(type, buffer, len, &p);                       \
-      if (rc <= 0) return rc;                                                \
-      *destination = p;                                                      \
-      return rc;                                                             \
+#  define MARSHAL_HELPER_FUNCTIONS(type, ttype)                               \
+    ssize_t type##_serialize(ttype *source, void *buffer);                    \
+    ssize_t type##_serialize(ttype *source, void *buffer)                     \
+    {                                                                         \
+      return marshal_serialize(type, source, buffer);                         \
+    }                                                                         \
+    size_t type##_unserialize(void *buffer, size_t len, ttype **destination); \
+    size_t type##_unserialize(void *buffer, size_t len, ttype **destination)  \
+    {                                                                         \
+      void *p;                                                                \
+      size_t rc;                                                              \
+      rc = marshal_unserialize(type, buffer, len, &p);                        \
+      if (rc <= 0) return rc;                                                 \
+      *destination = p;                                                       \
+      return rc;                                                              \
     }
 #  define MARSHAL_BEGIN(type)         \
     struct marshal_info MARSHAL_INFO( \

--- a/src/version.c
+++ b/src/version.c
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include "compat/compat.h"
+#include "log.h"
 
 static void
 version_display_array(FILE *destination, const char *prefix, const char *const *items)

--- a/tests/check_bitmap.c
+++ b/tests/check_bitmap.c
@@ -50,7 +50,7 @@ START_TEST(test_some_bits)
 }
 END_TEST
 
-Suite *
+static Suite *
 bitmap_suite(void)
 {
 	Suite *s = suite_create("Bitmap handling");

--- a/tests/check_cdp.c
+++ b/tests/check_cdp.c
@@ -498,7 +498,7 @@ END_TEST
 
 #endif
 
-Suite *
+static Suite *
 cdp_suite(void)
 {
 	Suite *s = suite_create("CDP");

--- a/tests/check_edp.c
+++ b/tests/check_edp.c
@@ -539,7 +539,7 @@ END_TEST
 
 #endif
 
-Suite *
+static Suite *
 edp_suite(void)
 {
 	Suite *s = suite_create("EDP");

--- a/tests/check_fixedpoint.c
+++ b/tests/check_fixedpoint.c
@@ -293,7 +293,7 @@ END_TEST
 
 #endif
 
-Suite *
+static Suite *
 fixedpoint_suite(void)
 {
 	Suite *s = suite_create("Fixed point representation");
@@ -333,8 +333,9 @@ fixedpoint_suite(void)
 }
 
 /* Disable leak detection sanitizer */
+int __lsan_is_turned_off(void);
 int
-__lsan_is_turned_off()
+__lsan_is_turned_off(void)
 {
 	return 1;
 }

--- a/tests/check_lldp.c
+++ b/tests/check_lldp.c
@@ -782,7 +782,7 @@ Specific (127)
 }
 END_TEST
 
-Suite *
+static Suite *
 lldp_suite(void)
 {
 	Suite *s = suite_create("LLDP");

--- a/tests/check_marshal.c
+++ b/tests/check_marshal.c
@@ -30,7 +30,7 @@
 */
 
 /* Use this callback to avoid some logs */
-void donothing(int pri, const char *msg) {};
+static void donothing(int pri, const char *msg) {};
 
 struct struct_simple {
 	int a1;
@@ -885,7 +885,7 @@ START_TEST(test_equality)
 }
 END_TEST
 
-Suite *
+static Suite *
 marshal_suite(void)
 {
 	Suite *s = suite_create("Marshalling");

--- a/tests/check_pattern.c
+++ b/tests/check_pattern.c
@@ -115,7 +115,7 @@ START_TEST(test_allowlist)
 }
 END_TEST
 
-Suite *
+static Suite *
 pattern_suite(void)
 {
 	Suite *s = suite_create("Pattern matching");

--- a/tests/check_snmp.c
+++ b/tests/check_snmp.c
@@ -310,7 +310,7 @@ struct lldpd_port port2 = {
 	.p_descr = "Gigabit Ethernet 1/7",
 };
 
-void
+static void
 snmp_config()
 {
 	starttime = test_starttime;
@@ -367,7 +367,7 @@ snmp_config()
 }
 
 /* Convert OID to a string. Static buffer. */
-char *
+static char *
 snmp_oidrepr(oid *name, size_t namelen)
 {
 	static char *buffer[4] = { NULL, NULL, NULL, NULL };
@@ -996,7 +996,7 @@ struct tree_node snmp_tree[] = { { { 1, 1, 1, 0 }, 4, ASN_INTEGER,
 #endif
 };
 
-char *
+static char *
 tohex(char *str, size_t len)
 {
 	static char *hex[] = { NULL, NULL };
@@ -1011,7 +1011,7 @@ tohex(char *str, size_t len)
 	return hex[1 - which];
 }
 
-int
+static int
 snmp_is_prefix_of(struct variable8 *vp, struct tree_node *n, char *repr)
 {
 	if (n->namelen < vp->namelen) return 0;
@@ -1020,7 +1020,7 @@ snmp_is_prefix_of(struct variable8 *vp, struct tree_node *n, char *repr)
 	return 1;
 }
 
-void
+static void
 snmp_merge(struct variable8 *v1, struct tree_node *n, struct variable *vp, oid *target,
     size_t *targetlen)
 {
@@ -1038,7 +1038,7 @@ snmp_merge(struct variable8 *v1, struct tree_node *n, struct variable *vp, oid *
 	    n->namelen * sizeof(oid));
 }
 
-void
+static void
 snmp_compare(struct tree_node *n, u_char *result, size_t varlen, oid *target,
     size_t targetlen, char *repr)
 {
@@ -1162,7 +1162,7 @@ START_TEST(test_getnext)
 }
 END_TEST
 
-Suite *
+static Suite *
 snmp_suite(void)
 {
 	Suite *s = suite_create("SNMP");

--- a/tests/check_sonmp.c
+++ b/tests/check_sonmp.c
@@ -185,7 +185,7 @@ END_TEST
 
 #endif
 
-Suite *
+static Suite *
 sonmp_suite(void)
 {
 	Suite *s = suite_create("SONMP");

--- a/tests/common.c
+++ b/tests/common.c
@@ -76,7 +76,7 @@ struct lldpd_ops pcap_ops = {
 };
 
 void
-pcap_setup()
+pcap_setup(void)
 {
 	static int serial = 0;
 	struct pcap_hdr hdr;
@@ -145,8 +145,9 @@ pcap_teardown()
 }
 
 /* Disable leak detection sanitizer */
+int __lsan_is_turned_off(void);
 int
-__lsan_is_turned_off()
+__lsan_is_turned_off(void)
 {
 	return 1;
 }

--- a/tests/common.h
+++ b/tests/common.h
@@ -39,7 +39,7 @@ extern struct lldpd_hardware hardware;
 extern struct lldpd_chassis chassis;
 
 int pcap_send(struct lldpd *, struct lldpd_hardware *, char *, size_t);
-void pcap_setup();
-void pcap_teardown();
+void pcap_setup(void);
+void pcap_teardown(void);
 
 #endif

--- a/tests/decode.c
+++ b/tests/decode.c
@@ -27,7 +27,7 @@
 
 #define BUFSIZE 2000
 
-char *
+static char *
 tohex(char *str, size_t len)
 {
 	static char *hex = NULL;
@@ -47,7 +47,7 @@ tohex(char *str, size_t len)
     exit(5);                                                                    \
   }
 
-int
+static int
 decode(char *frame, int size, struct lldpd_hardware *hardware,
     struct lldpd_chassis **nchassis, struct lldpd_port **nport)
 {


### PR DESCRIPTION
String literals aren't assigned to non-const char pointers anymore, they aren't returned via non-const char pointers, const strings aren't passed arround via non-const pointers etc.

As a side effect, this eliminates all -Wdiscarded-qualifiers warnings.

Symbol visibility is minimized by declaring additional functions static, i.e those which are only used inside a single translation unit.

Also, a few includes are added such that all non-static function definitions 'see' their declarations - such that accidental differences in signatures immedialy yield compile errors or warnings.

A few macros are also modified to emit forward declarations for non-static functions in order to eliminate noise when compiling with -Wmissing-prototypes.
However, it might make sense to move those non-static function definitions from a header into a dedicated translation unit, at some point.