### PR TITLE
priv: disable LLDP in firmware for Intel X7xx cards on FreeBSD

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ lldpd (1.0.19)
  * Changes:
    + Support of both Apple Silicon and Intel for macOS package.
    + Add cvlan/svlan/tpmr capabilities.
+   + Disable LLDP in firmware for Intel X7xx cards on FreeBSD.
 
 lldpd (1.0.18)
  * Changes (breaking):

--- a/README.md
+++ b/README.md
@@ -449,8 +449,15 @@ for f in /sys/kernel/debug/i40e/*/command; do
     echo lldp stop > $f
 done
 ```
+On FreeBSD, use `sysctl` stop the embedded LLDP daemon:
+```sh
+for oid in $(sysctl -Nq dev.ixl | grep fw_lldp); do
+    sysctl $oid=0
+done
+```
 This may also apply to the `ice` (Intel E8xx cards) driver. These
-steps are not necessary with a recent version of `lldpd` (1.0.11+).
+steps are not necessary with a recent version of `lldpd` (1.0.11+ for
+Linux, 1.0.19+ for FreeBSD).
 
 ## License
 


### PR DESCRIPTION
Fixes #660.

Tested on FreeBSD 13.3-RELEASE (amd64) with an Intel X710 running firmware version "fw 8.84.66032 api 1.14 nvm 8.40 etid 8000c815 oem 20.5120.11".