### PR TITLE
fix endless loop in redefined malloc/remalloc functions on system usi…

### DIFF
--- a/src/compat/malloc.c
+++ b/src/compat/malloc.c
@@ -1,10 +1,10 @@
 /* -*- mode: c; c-file-style: "openbsd" -*- */
 /* malloc replacement that can allocate 0 byte */
 
-#undef malloc
 #include <stdlib.h>
 #include <sys/types.h>
 #include "compat.h"
+#undef malloc
 
 /* Allocate an N-byte block of memory from the heap.
    If N is zero, allocate a 1-byte block.  */

--- a/src/compat/realloc.c
+++ b/src/compat/realloc.c
@@ -1,10 +1,10 @@
 /* -*- mode: c; c-file-style: "openbsd" -*- */
 /* realloc replacement that can reallocate 0 byte or NULL pointers*/
 
-#undef realloc
 #include <stdlib.h>
 #include <sys/types.h>
 #include "compat.h"
+#undef realloc
 
 /* Reallocate an N-byte block of memory from the heap.
    If N is zero, allocate a 1-byte block.  */


### PR DESCRIPTION
lldpcli and lldpd will entere into endless loop on our hardware box after upgrading lldap from 1.0.4 to 1.0.18. 
This issue is caused by endless call in malloc/remalloc function.

