### PR TITLE
fix: Always TX fast start complient to IEEE802.1as-2009

### DIFF
--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -123,7 +123,6 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 		levent_send_now(cfg);
 	}
 
-#ifdef ENABLE_LLDPMED
 	if (CHANGED(c_enable_fast_start)) {
 		cfg->g_config.c_enable_fast_start = config->c_enable_fast_start;
 		log_debug("rpc", "client asked to %s fast start",
@@ -134,7 +133,6 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 		    config->c_tx_fast_interval);
 		cfg->g_config.c_tx_fast_interval = config->c_tx_fast_interval;
 	}
-#endif
 	if (CHANGED_STR(c_iface_pattern)) {
 		log_debug("rpc", "change interface pattern to %s",
 		    config->c_iface_pattern ? config->c_iface_pattern : "(NULL)");

--- a/src/daemon/event.c
+++ b/src/daemon/event.c
@@ -812,12 +812,10 @@ levent_send_pdu(evutil_socket_t fd, short what, void *arg)
 	log_debug("event", "trigger sending PDU for port %s", hardware->h_ifname);
 	lldpd_send(hardware);
 
-#ifdef ENABLE_LLDPMED
 	if (hardware->h_tx_fast > 0) hardware->h_tx_fast--;
 
 	if (hardware->h_tx_fast > 0)
 		tx_interval = hardware->h_cfg->g_config.c_tx_fast_interval * 1000;
-#endif
 
 	struct timeval tv;
 	tv.tv_sec = tx_interval / 1000;

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -740,8 +740,7 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 #endif
 	}
 
-#ifdef ENABLE_LLDPMED
-	if (!oport && port->p_chassis->c_med_type) {
+	if (!oport) {
 		/* New neighbor, fast start */
 		if (hardware->h_cfg->g_config.c_enable_fast_start &&
 		    !hardware->h_tx_fast) {
@@ -754,7 +753,6 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 
 		levent_schedule_pdu(hardware);
 	}
-#endif
 
 	return;
 }
@@ -1571,8 +1569,8 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	int i, found, advertise_version = 1;
 #ifdef ENABLE_LLDPMED
 	int lldpmed = 0, noinventory = 0;
-	int enable_fast_start = 1;
 #endif
+	int enable_fast_start = 1;
 	char *descr_override = NULL;
 	char *platform_override = NULL;
 	char *lsb_release = NULL;
@@ -1935,11 +1933,9 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	cfg->g_config.c_ttl = cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold;
 	cfg->g_config.c_ttl = MIN((cfg->g_config.c_ttl + 999) / 1000, 65535);
 	cfg->g_config.c_max_neighbors = LLDPD_MAX_NEIGHBORS;
-#ifdef ENABLE_LLDPMED
 	cfg->g_config.c_enable_fast_start = enable_fast_start;
 	cfg->g_config.c_tx_fast_init = LLDPD_FAST_INIT;
 	cfg->g_config.c_tx_fast_interval = LLDPD_FAST_TX_INTERVAL;
-#endif
 #ifdef USE_SNMP
 	cfg->g_snmp = snmp;
 	cfg->g_snmp_agentx = agentx;

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -233,11 +233,11 @@ _lldpctl_atom_get_int_config(lldpctl_atom_t *atom, lldpctl_key_t key)
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_lldpmed_noinventory:
 		return c->config->c_noinventory;
+#endif
 	case lldpctl_k_config_fast_start_enabled:
 		return c->config->c_enable_fast_start;
 	case lldpctl_k_config_fast_start_interval:
 		return c->config->c_tx_fast_interval;
-#endif
 	case lldpctl_k_config_tx_hold:
 		return c->config->c_tx_hold;
 	case lldpctl_k_config_max_neighbors:
@@ -284,7 +284,6 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key, long int v
 	case lldpctl_k_config_chassis_mgmt_advertise:
 		config.c_mgmt_advertise = c->config->c_mgmt_advertise = value;
 		break;
-#ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_fast_start_enabled:
 		config.c_enable_fast_start = c->config->c_enable_fast_start = value;
 		break;
@@ -292,7 +291,6 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key, long int v
 		config.c_tx_fast_interval = value;
 		if (value > 0 && value <= 3600) c->config->c_tx_fast_interval = value;
 		break;
-#endif
 	case lldpctl_k_config_tx_hold:
 		config.c_tx_hold = value;
 		if (value > 0 && value <= 100) c->config->c_tx_hold = value;

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -410,10 +410,10 @@ struct lldpd_config {
 
 #ifdef ENABLE_LLDPMED
 	int c_noinventory;	 /* Don't send inventory with LLDP-MED */
+#endif
 	int c_enable_fast_start; /* enable fast start */
 	int c_tx_fast_init;	 /* Num of lldpd lldppdu's for fast start */
 	int c_tx_fast_interval;	 /* Time intr between sends during fast start */
-#endif
 	int c_tx_hold;		       /* Transmit hold */
 	int c_bond_slave_src_mac_type; /* Src mac type in lldp frames over bond
 					  slaves */
@@ -501,9 +501,7 @@ struct lldpd_hardware {
 	struct lldpd_port h_lport;	   /* Port attached to this hardware port */
 	TAILQ_HEAD(, lldpd_port) h_rports; /* Remote ports */
 
-#ifdef ENABLE_LLDPMED
 	int h_tx_fast; /* current tx fast start count */
-#endif
 };
 MARSHAL_BEGIN(lldpd_hardware)
 MARSHAL_IGNORE(lldpd_hardware, h_entries.tqe_next)


### PR DESCRIPTION
That's a PR for [this issue](https://github.com/lldpd/lldpd/issues/680). It works for me, however, I did not adjust unit tests.