### PR TITLE
fix: add socket lock to AppArmor policy

### DIFF
--- a/src/daemon/usr.sbin.lldpd.in
+++ b/src/daemon/usr.sbin.lldpd.in
@@ -31,6 +31,7 @@
   # PID file and socket
   @LLDPD_PID_FILE@ rw,
   @LLDPD_CTL_SOCKET@ rw,
+  @LLDPD_CTL_SOCKET@.lock rwk,
 
   # Chroot setup
   @PRIVSEP_CHROOT@ w,


### PR DESCRIPTION
Resolves:

```
2024-10-27T20:05:27 [WARN/lldpctl] cannot get lock on /run/lldpd/lldpd.socket.lock: Permission denied
2024-10-27T20:05:27 [INFO/lldpctl] an error occurred while executing last command
2024-10-27T20:05:27 [INFO/lldpctl] lldpd should resume operations
```