### PR TITLE
feat: Add lldpctl_watch_sync_unblock

### DIFF
--- a/src/client/show.c
+++ b/src/client/show.c
@@ -238,8 +238,10 @@ cmd_watch_neighbors(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_en
 	}
 	while (1) {
 		if (lldpctl_watch(conn) < 0) {
-			log_warnx("lldpctl", "unable to watch for neighbors. %s",
-			    lldpctl_last_strerror(conn));
+			if (lldpctl_last_error(conn) != LLDPCTL_ERR_CALLBACK_UNBLOCK) {
+				log_warnx("lldpctl", "unable to watch for neighbors. %s",
+					lldpctl_last_strerror(conn));
+			}
 			return 0;
 		}
 		if (limit > 0 && wa.nb >= limit) return 1;

--- a/src/lib/atom.c
+++ b/src/lib/atom.c
@@ -401,6 +401,23 @@ lldpctl_watch(lldpctl_conn_t *conn)
 	return 0;
 }
 
+void
+lldpctl_watch_sync_unblock(lldpctl_conn_t *conn)
+{
+	if (conn->state != CONN_STATE_WATCHING)
+		return;
+
+	if (!conn->sync_clb)
+		return;
+
+	struct lldpctl_conn_sync_t *data = conn->user_data;
+
+	if (data->pipe_fd[1] != -1) {
+		/* Write to the pipe to unblock the read */
+		write(data->pipe_fd[1], "x", 1);
+	}
+}
+
 lldpctl_atom_t *
 lldpctl_get_configuration(lldpctl_conn_t *conn)
 {

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -76,8 +76,9 @@ struct lldpctl_conn_t {
 
 /* User data for synchronous callbacks. */
 struct lldpctl_conn_sync_t {
+	int epoll_fd; /* File descriptor for epoll. */
 	int fd; /* File descriptor to the socket. */
-	int pipe_fd[2]; /* Pipe file descriptors required for unblocking a read-blocked watcher */
+	int pipe_fd[2]; /* Pipe file descriptors required for unblocking a read-blocked watcher. */
 };
 
 ssize_t _lldpctl_needs(lldpctl_conn_t *lldpctl, size_t length);

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -30,6 +30,7 @@ struct lldpctl_conn_t {
 	lldpctl_recv_callback recv; /* Receive callback */
 	lldpctl_send_callback send; /* Send callback */
 	void *user_data;	    /* Callback user data */
+	uint8_t sync_clb;       /* If set synchronous callbacks are used */
 
 	/* IO state handling. */
 	uint8_t *input_buffer;	/* Current input/output buffer */
@@ -76,6 +77,7 @@ struct lldpctl_conn_t {
 /* User data for synchronous callbacks. */
 struct lldpctl_conn_sync_t {
 	int fd; /* File descriptor to the socket. */
+	int pipe_fd[2]; /* Pipe file descriptors required for unblocking a read-blocked watcher */
 };
 
 ssize_t _lldpctl_needs(lldpctl_conn_t *lldpctl, size_t length);

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -76,7 +76,6 @@ struct lldpctl_conn_t {
 
 /* User data for synchronous callbacks. */
 struct lldpctl_conn_sync_t {
-	int epoll_fd; /* File descriptor for epoll. */
 	int fd; /* File descriptor to the socket. */
 	int pipe_fd[2]; /* Pipe file descriptors required for unblocking a read-blocked watcher. */
 };

--- a/src/lib/errors.c
+++ b/src/lib/errors.c
@@ -52,6 +52,8 @@ lldpctl_strerror(lldpctl_error_t error)
 		return "Not enough memory available";
 	case LLDPCTL_ERR_CALLBACK_FAILURE:
 		return "A failure occurred during callback processing";
+	case LLDPCTL_ERR_CALLBACK_UNBLOCK:
+		return "Forced callback to unblock";
 	}
 	return "Unknown error code";
 }

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -330,7 +330,11 @@ typedef enum {
 	/**
 	 * An error occurred in a user provided callback.
 	 */
-	LLDPCTL_ERR_CALLBACK_FAILURE = -902
+	LLDPCTL_ERR_CALLBACK_FAILURE = -902,
+	/**
+	 * The callback was forced to unblock.
+	 */
+	LLDPCTL_ERR_CALLBACK_UNBLOCK = -903
 } lldpctl_error_t;
 
 /**
@@ -545,6 +549,16 @@ int lldpctl_watch_callback2(lldpctl_conn_t *conn, lldpctl_change_callback2 cb,
  * as a main loop when using the builtin blocking IO mechanism.
  */
 int lldpctl_watch(lldpctl_conn_t *conn);
+
+/**
+ * Unblock another thread that's waiting for the next change on that synchronous callback connection.
+ *
+ * @param conn Synchronous callback connection with lldpd.
+ *
+ * If some thread is blocked at @ref lldpctl_watch() with the same synchronous callback @p conn,
+ * then this function will unblock it. Otherwise, this function will have no effect.
+ */
+void lldpctl_watch_sync_unblock(lldpctl_conn_t *conn);
 
 /**
  * @defgroup liblldpctl_atom_get_special Retrieving atoms from lldpd

--- a/src/lib/lldpctl.map
+++ b/src/lib/lldpctl.map
@@ -47,6 +47,7 @@ LIBLLDPCTL_4.6 {
   lldpctl_strerror;
   lldpctl_watch;
   lldpctl_watch_callback;
+  lldpctl_watch_sync_unblock;
 
  local:
   *;


### PR DESCRIPTION
This PR solves #675 by adding the new function `lldpctl_watch_sync_unblock`. It's applicable only for synchronous callback connections as others have their read function under control anyway. 

The change is thread safe since `lldpctl_watch_sync_unblock` only needs to check whether the connection refers to a synchronous callback connection. It then unblock another thread's `lldpctl_watch` call by sending data using a pipe, which listens to data from  both the daemon and the pipe.

A new error code `LLDPCTL_ERR_CALLBACK_UNBLOCK` has been introduced in order to distinguish the nature of why `lldpctl_watch` failed.