### PR TITLE
fix global tx hold/interval and ttl range

### DIFF
--- a/src/client/display.c
+++ b/src/client/display.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
+#include <sys/param.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -599,7 +600,7 @@ display_local_ttl(struct writer *w, lldpctl_conn_t *conn, int details)
 	tx_interval =
 	    lldpctl_atom_get_int(configuration, lldpctl_k_config_tx_interval_ms);
 
-	tx_interval = (tx_interval * tx_hold + 999) / 1000;
+	tx_interval = MIN((tx_interval * tx_hold + 999) / 1000, 65535);
 
 	if (asprintf(&ttl, "%lu", tx_interval) == -1) {
 		log_warnx("lldpctl", "not enough memory to build TTL.");

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -75,7 +75,7 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 	if (CHANGED(c_tx_interval) && config->c_tx_interval != 0) {
 		if (config->c_tx_interval < 0) {
 			log_debug("rpc", "client asked for immediate retransmission");
-		} else {
+		} else if (config->c_tx_interval <= 3600 * 1000) {
 			log_debug("rpc", "client change transmit interval to %d ms",
 			    config->c_tx_interval);
 			cfg->g_config.c_tx_interval = config->c_tx_interval;
@@ -86,7 +86,8 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 		}
 		levent_send_now(cfg);
 	}
-	if (CHANGED(c_tx_hold) && config->c_tx_hold > 0) {
+	if (CHANGED(c_tx_hold) && config->c_tx_hold > 0 &&
+	    config->c_tx_hold <= 100) {
 		log_debug("rpc", "client change transmit hold to %d",
 		    config->c_tx_hold);
 		cfg->g_config.c_tx_hold = config->c_tx_hold;

--- a/src/daemon/protocols/edp.c
+++ b/src/daemon/protocols/edp.c
@@ -25,6 +25,7 @@
 #  include <errno.h>
 #  include <arpa/inet.h>
 #  include <fnmatch.h>
+#  include <sys/param.h>
 
 static int seq = 0;
 
@@ -296,7 +297,7 @@ edp_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardwar
 		goto malformed;
 	}
 	port->p_ttl = cfg ? cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold : 0;
-	port->p_ttl = (port->p_ttl + 999) / 1000;
+	port->p_ttl = MIN((port->p_ttl + 999) / 1000, 65535);
 	chassis->c_id_subtype = LLDP_CHASSISID_SUBTYPE_LLADDR;
 	chassis->c_id_len = ETHER_ADDR_LEN;
 	if ((chassis->c_id = (char *)malloc(ETHER_ADDR_LEN)) == NULL) {

--- a/src/daemon/protocols/sonmp.c
+++ b/src/daemon/protocols/sonmp.c
@@ -24,6 +24,7 @@
 #  include <unistd.h>
 #  include <errno.h>
 #  include <arpa/inet.h>
+#  include <sys/param.h>
 
 static struct sonmp_chassis sonmp_chassis_types[] = {
 	{ 1, "unknown (via SONMP)" },
@@ -369,7 +370,7 @@ sonmp_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 	TAILQ_INSERT_TAIL(&chassis->c_mgmt, mgmt, m_entries);
 	port->p_ttl =
 	    cfg ? (cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold) : LLDPD_TTL;
-	port->p_ttl = (port->p_ttl + 999) / 1000;
+	port->p_ttl = MIN((port->p_ttl + 999) / 1000, 65535);
 
 	port->p_id_subtype = LLDP_PORTID_SUBTYPE_LOCAL;
 


### PR DESCRIPTION
In the previous commits a73e04f46ebe and 7b9abb819337. I forgot to fix the ttl range on ports and global tx hold/interval range. 