### PR TITLE
autoconf: Use m4sh syntax where appropriate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,9 +45,9 @@ gl_LD_VERSION_SCRIPT
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CC_C99
-if test x"$ac_cv_prog_cc_c99" = x"no"; then
+AS_IF([test x"$ac_cv_prog_cc_c99" = x"no"], [
   AC_MSG_FAILURE([*** C99 support is mandatory])
-fi
+])
 AC_PROG_CPP
 AM_PROG_CC_C_O
 LT_INIT
@@ -112,56 +112,56 @@ AC_ARG_ENABLE([pie],
   [pie="$enableval"],
   [pie="no"])
 
-if test x"$hardening" != x"no"; then
+AS_IF([test x"$hardening" != x"no"], [
   AX_CFLAGS_GCC_OPTION([-fstack-protector], [LLDP_CFLAGS])
   AX_CFLAGS_GCC_OPTION([-fstack-protector-all], [LLDP_CFLAGS])
   AX_CFLAGS_GCC_OPTION([-fstack-protector-strong], [LLDP_CFLAGS])
   AX_CFLAGS_GCC_OPTION([-fstack-protector-strong], [LLDP_CFLAGS])
   AX_CFLAGS_GCC_OPTION([-fstack-clash-protection], [LLDP_CFLAGS])
   AX_CFLAGS_GCC_OPTION([-D_FORTIFY_SOURCE=2], [LLDP_CPPFLAGS])
-fi
-if test x"$pie" = x"yes"; then
+])
+AS_IF([test x"$pie" = x"yes"], [
   AX_CFLAGS_GCC_OPTION([-fPIE], [LLDP_CFLAGS])
   AX_LDFLAGS_OPTION([-fPIE -pie], [LLDP_BIN_LDFLAGS],
     [AX_LDFLAGS_OPTION([-fPIE -Wl,-pie], [LLDP_BIN_LDFLAGS])])
-fi
+])
 
 # Sanitizers
 AC_ARG_ENABLE([sanitizers],
   AS_HELP_STRING([--enable-sanitizers],
     [Enable code instrumentation with selected sanitizers @<:@default=no@:>@]),
   [
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-if test x"$sanitizers" != x; then
-  LLDP_CFLAGS="$LLDP_CFLAGS $sanitizers"
-  LLDP_LDFLAGS="$LLDP_LDFLAGS $sanitizers"
-  AC_DEFINE([HAVE_ADDRESS_SANITIZER], 1, [Define if have both address and leak sanitizer])
-elif test x"$hardening" != x"no"; then
-  AX_LDFLAGS_OPTION([-fsanitize=safe-stack], [LLDP_BIN_LDFLAGS])
-  if test x"$ax_cv_ld_check_flag__fsanitize_safe_stack" != x"no"; then
-    AX_CFLAGS_GCC_OPTION([-fsanitize=safe-stack], [LLDP_CFLAGS])
-  fi
-fi
+    AS_CASE([$enableval],
+	[no], [sanitizers=],
+	[yes], [sanitizers="-fsanitize=address,undefined"],
+	[sanitizers="-fsanitize=$enableval"]
+    )
+    AS_IF([test x"$sanitizers" != x], [
+      LLDP_CFLAGS="$LLDP_CFLAGS $sanitizers"
+      LLDP_LDFLAGS="$LLDP_LDFLAGS $sanitizers"
+    AC_DEFINE([HAVE_ADDRESS_SANITIZER], 1, [Define if have both address and leak sanitizer])
+    ], [ test x"$hardening" != x"no"], [
+      AX_LDFLAGS_OPTION([-fsanitize=safe-stack], [LLDP_BIN_LDFLAGS])
+    AS_IF([test x"$ax_cv_ld_check_flag__fsanitize_safe_stack" != x"no"], [
+      AX_CFLAGS_GCC_OPTION([-fsanitize=safe-stack], [LLDP_CFLAGS])
+    ])
   ])
+])
 
 # Fuzzer
 AC_ARG_ENABLE([fuzzer],
   AS_HELP_STRING([--enable-fuzzer],
     [Enable fuzzing @<:@default=no@:>@]),
   [
-case "$enableval" in
-    no) fuzzer= ;;
-    yes) fuzzer="-fsanitize=fuzzer" ;;
-    *) fuzzer="$enableval" ;;
-esac
-if test x"$fuzzer" != x; then
-  AC_SUBST([FUZZ_DECODE_ENGINE], ["$fuzzer"])
-  AX_CFLAGS_GCC_OPTION([-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION], [LLDP_CFLAGS])
-fi
+    AS_CASE([$enableval],
+      [no], [fuzzer=],
+      [yes], [fuzzer="-fsanitize=fuzzer"],
+      [fuzzer="$enableval"]
+    )
+    AS_IF([test x"$fuzzer" != x], [
+      AC_SUBST([FUZZ_DECODE_ENGINE], ["$fuzzer"])
+      AX_CFLAGS_GCC_OPTION([-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION], [LLDP_CFLAGS])
+    ])
   ])
 
 # Code coverage
@@ -170,10 +170,10 @@ AC_ARG_ENABLE([gcov],
     [Enable coverage instrumentation @<:@default=no@:>@]),
     [gcov="$enableval"],
     [gcov="no"])
-if test x"$gcov" != x"no"; then
+AS_IF([test x"$gcov" != x"no"], [
   LLDP_CFLAGS="$LLDP_CFLAGS --coverage"
   LLDP_LDFLAGS="$LLDP_LDFLAGS --coverage"
-fi
+])
 
 # OS
 lldp_CHECK_OS
@@ -205,7 +205,7 @@ AC_ARG_WITH([libbsd],
     [Use libbsd @<:@default=auto@:>@]),
   [],
   [with_libbsd=auto])
-if test x"$with_libbsd" != x"no"; then
+AS_IF([test x"$with_libbsd" != x"no"], [
   PKG_CHECK_MODULES([libbsd], [libbsd-overlay], [
     _save_CFLAGS="$CFLAGS"
     _save_LIBS="$LIBS"
@@ -224,18 +224,18 @@ if test x"$with_libbsd" != x"no"; then
         AC_MSG_RESULT(no)
         CFLAGS="$_save_CFLAGS"
         LIBS="$_save_LIBS"
-        if test x"$with_libbsd" = x"yes"; then
+        AS_IF([test x"$with_libbsd" = x"yes"], [
            AC_MSG_FAILURE([*** no libbsd support found])
-        fi
+        ])
         with_libbsd=no
       ])
   ], [
-    if test x"$with_libbsd" = x"yes"; then
+    AS_IF([test x"$with_libbsd" = x"yes"], [
        AC_MSG_FAILURE([*** no libbsd support found])
-    fi
+    ])
     with_libbsd=no
   ])
-fi
+])
 
 # setproctitle may have an _init function
 AC_REPLACE_FUNCS([setproctitle])
@@ -289,16 +289,16 @@ AC_ARG_WITH([readline],
     [Enable the use of readline-like library @<:@default=auto@:>@]),
   [],
   [with_readline=auto])
-if test x"$with_readline" != x"no"; then
+AS_IF([test x"$with_readline" != x"no"], [
    AX_LIB_READLINE_LLDPD
-   if test x"$with_readline" != x"check" -a x"$with_readline" != x"auto"; then
-     if test x"$ax_cv_lib_readline" = x"no"; then
+   AS_IF([test x"$with_readline" != x"check" -a x"$with_readline" != x"auto"], [
+     AS_IF([test x"$ax_cv_lib_readline" = x"no"], [
        AC_MSG_FAILURE([*** no readline support found])
-     fi
-   fi
-else
+     ])
+   ])
+], [
    ax_cv_lib_readline="no"
-fi
+])
 
 # SNMP
 AC_ARG_WITH([snmp],
@@ -368,9 +368,9 @@ lldp_ARG_WITH([privsep-group], [Which group to use for privilege separation], [_
 
 # Directories
 dnl On autoconf 2.69 and before, runstatedir is not configurable, let be able to use it anyway
-if test "x$runstatedir" = x; then
+AS_IF([test "x$runstatedir" = x], [
     AC_SUBST([runstatedir], ['${localstatedir}/run'])
-fi
+])
 lldp_ARG_WITH([privsep-chroot], [Which directory to use to chroot lldpd], [${runstatedir}/lldpd])
 lldp_ARG_WITH([lldpd-ctl-socket], [Path to socket for communication with lldpd], [${runstatedir}/lldpd.socket])
 lldp_ARG_WITH([lldpd-pid-file], [Path to lldpd PID file], [${runstatedir}/lldpd.pid])
@@ -395,26 +395,26 @@ lldp_ARG_ENABLE([custom], [Custom TLV support], [yes])
 # Oldies
 MIN_LINUX_KERNEL_VERSION=2.6.39
 lldp_ARG_ENABLE([oldies], [compatibility with Linux kernel older than 2.6.39], [no])
-if test x"$os" = x"Linux"; then
-    if test x"$enable_oldies" = x"no"; then
+AS_IF([test x"$os" = x"Linux"], [
+    AS_IF([test x"$enable_oldies" = x"no"], [
       AC_DEFINE_UNQUOTED(MIN_LINUX_KERNEL_VERSION, "[$MIN_LINUX_KERNEL_VERSION]", [Minimal Linux kernel version required])
-    else
+    ], [
       AC_DEFINE(MIN_LINUX_KERNEL_VERSION, "2.6.11", [Minimal kernel version required])
-    fi
-fi
+    ])
+])
 
 AX_BUILD_DATE_EPOCH(BUILD_DATE, "%FT%TZ", [BUILD_DATE="(unknown)"])
 AC_DEFINE_UNQUOTED(BUILD_DATE, "[$BUILD_DATE]", [Build date and time])
 
 dnl per reproducible-builds.org check SOURCE_DATE_EPOCH
 dnl
-if test -z "${SOURCE_DATE_EPOCH+set}" ; then
+AS_IF([test -z "${SOURCE_DATE_EPOCH+set}"], [
 AC_DEFINE_UNQUOTED(LLDP_CC, "[$CC $LLDP_CFLAGS $LLDP_CPPFLAGS $CFLAGS $CPPFLAGS]", [C compiler command])
 AC_DEFINE_UNQUOTED(LLDP_LD, "[$LD $LLDP_LDFLAGS $LLDP_BIN_LDFLAGS $LDFLAGS $LIBS]", [Linker compiler command])
-else
+], [
 AC_DEFINE_UNQUOTED(LLDP_CC, "[C compiler command is not available for reproducible builds]", [C compiler command])
 AC_DEFINE_UNQUOTED(LLDP_LD, "[Linker compiler command is not available for reproducible builds]", [Linker compiler command])
-fi
+])
 
 #######################
 # Output results
@@ -429,16 +429,16 @@ AM_CONDITIONAL([USE_XML], [test x"$with_xml" = x"yes"])
 AM_CONDITIONAL([USE_SECCOMP], [test x"$with_seccomp" = x"yes"])
 dnl If old default of AR_FLAGS is otherwise being used (because of older automake),
 dnl replace it with one without 'u'
-if test "x$AR_FLAGS" = "xcru" ; then
+AS_IF([test "x$AR_FLAGS" = "xcru"], [
   AR_FLAGS="cr"
-fi
+])
 AC_OUTPUT
 
-if test x"$LIBEVENT_EMBEDDED" = x; then
+AS_IF([test x"$LIBEVENT_EMBEDDED" = x], [
    libevent=system
-else
+], [
    libevent=embedded
-fi
+])
 
 cat <<EOF
 

--- a/m4/alignof.m4
+++ b/m4/alignof.m4
@@ -7,7 +7,7 @@ AC_DEFUN([lldp_CHECK_ALIGNOF],[
                       [ lldp_cv_check_alignof="yes" ],
                       [ lldp_cv_check_alignof="no" ])
   ])
-  if test x"$lldp_cv_check_alignof" = x"yes"; then
+  AS_IF([test x"$lldp_cv_check_alignof" = x"yes"], [
      AC_DEFINE([HAVE_ALIGNOF], [1], [Define if __alignof__ operator is available])
-  fi
+  ])
 ])

--- a/m4/args.m4
+++ b/m4/args.m4
@@ -10,13 +10,13 @@ AC_DEFUN([lldp_AC_EXPAND], [
   exec_prefix_save=$exec_prefix
 
   dnl if no prefix given, then use /usr/local, the default prefix
-  if test "x$prefix" = "xNONE"; then
+  AS_IF([test "x$prefix" = "xNONE"], [
     prefix="$ac_default_prefix"
-  fi
+  ])
   dnl if no exec_prefix given, then use prefix
-  if test "x$exec_prefix" = "xNONE"; then
+  AS_IF([test "x$exec_prefix" = "xNONE"], [
     exec_prefix=$prefix
-  fi
+  ])
 
   full_var="$1"
   dnl loop until it doesn't change anymore
@@ -72,10 +72,10 @@ AC_DEFUN([lldp_ARG_ENABLE],[
 		[Enable $2 @<:@default=$3@:>@]),
 	[enable_$1=$enableval], [enable_$1=$3])
   AC_MSG_CHECKING(whether to enable $2)
-  if test x"$enable_$1" = x"yes"; then
+  AS_IF([test x"$enable_$1" = x"yes"], [
      AC_MSG_RESULT(yes)
      AC_DEFINE([ENABLE_]AS_TR_CPP([$1]),, [$2])
-  else
+  ], [
      AC_MSG_RESULT(no)
-  fi
+  ])
 ])

--- a/m4/ax_cflags_gcc_option.m4
+++ b/m4/ax_cflags_gcc_option.m4
@@ -96,16 +96,18 @@ done
  AC_LANG_RESTORE
 ])
 AS_VAR_COPY([ac_res], [VAR])
-case ".${ac_res}" in
-     .ok|.ok,*) m4_ifvaln($3,$3) ;;
-   .|.no|.no,*) m4_ifvaln($4,$4) ;;
-   *) m4_ifvaln($3,$3,[
-   if echo " $[]m4_ifval($2,$2,FLAGS) " | grep " ${ac_res} " 2>&1 >/dev/null
-   then AC_RUN_LOG([: m4_ifval($2,$2,FLAGS) does contain ${ac_res}])
-   else AC_RUN_LOG([: m4_ifval($2,$2,FLAGS)="$m4_ifval($2,$2,FLAGS) ${ac_res}"])
+AS_CASE([.${ac_res}],
+     [.ok|.ok,*], [m4_ifvaln($3,$3)],
+   [.|.no|.no,*], [m4_ifvaln($4,$4)],
+   [m4_ifvaln($3,$3,[
+    AS_IF([echo " $[]m4_ifval($2,$2,FLAGS) " | grep " ${ac_res} " 2>&1 >/dev/null], [
+	AC_RUN_LOG([: m4_ifval($2,$2,FLAGS) does contain ${ac_res}])], [
+	AC_RUN_LOG([: m4_ifval($2,$2,FLAGS)="$m4_ifval($2,$2,FLAGS) ${ac_res}"])
                       m4_ifval($2,$2,FLAGS)="$m4_ifval($2,$2,FLAGS) ${ac_res}"
-   fi ]) ;;
-esac
+    ])
+   ])
+])
+
 AS_VAR_POPDEF([VAR])dnl
 AS_VAR_POPDEF([FLAGS])dnl
 ])

--- a/m4/ax_lib_readline.m4
+++ b/m4/ax_lib_readline.m4
@@ -69,49 +69,49 @@
 
 AU_ALIAS([VL_LIB_READLINE], [AX_LIB_READLINE_LLDPD])
 AC_DEFUN([AX_LIB_READLINE_LLDPD], [
-  if test -z "$ax_cv_lib_readline"; then
+  AS_IF([test -z "$ax_cv_lib_readline"], [
     PKG_CHECK_MODULES(READLINE, readline, [ax_cv_lib_readline="$READLINE_LIBS"; ax_cv_lib_readline_cflags="$READLINE_CFLAGS"], [:])
-  fi
-  if test -z "$ax_cv_lib_readline"; then
+  ])
+  AS_IF([test -z "$ax_cv_lib_readline"], [
     PKG_CHECK_MODULES(LIBEDIT, libedit, [ax_cv_lib_readline="$LIBEDIT_LIBS"; ax_cv_lib_readline_cflags="$LIBEDIT_CFLAGS"], [:])
-  fi
-  if test -z "$ax_cv_lib_readline"; then
+  ])
+  AS_IF([test -z "$ax_cv_lib_readline"], [
     PKG_CHECK_MODULES(LIBEDITLINE, libeditline, [ax_cv_lib_readline="$LIBEDITLINE_LIBS"; ax_cv_lib_readline_cflags="$LIBEDITLINE_CFLAGS"], [:])
-  fi
-  if test -z "$ax_cv_lib_readline"; then
+  ])
+  AS_IF([test -z "$ax_cv_lib_readline"], [
     AC_CACHE_CHECK([for a readline compatible library],
                  ax_cv_lib_readline, [
       _save_LIBS="$LIBS"
       for readline_lib in readline edit editline; do
         for termcap_lib in "" termcap curses ncurses; do
-          if test -z "$termcap_lib"; then
+          AS_IF([test -z "$termcap_lib"], [
             TRY_LIB="-l$readline_lib"
-          else
+          ], [
             TRY_LIB="-l$readline_lib -l$termcap_lib"
-          fi
+          ])
           LIBS="$ORIG_LIBS $TRY_LIB"
           for readline_func in readline rl_insert_text rl_forced_update_display; do
             AC_TRY_LINK_FUNC($readline_func, ax_cv_lib_readline="$TRY_LIB", ax_cv_lib_readline="")
-            if test -z "$ax_cv_lib_readline"; then
+            AS_IF([test -z "$ax_cv_lib_readline"], [
               break
-            fi
+            ])
           done
-          if test -n "$ax_cv_lib_readline"; then
+          AS_IF([test -n "$ax_cv_lib_readline"], [
             break
-          fi
+          ])
         done
-        if test -n "$ax_cv_lib_readline"; then
+        AS_IF([test -n "$ax_cv_lib_readline"], [
           break
-        fi
+        ])
       done
-      if test -z "$ax_cv_lib_readline"; then
+      AS_IF([test -z "$ax_cv_lib_readline"], [
         ax_cv_lib_readline="no"
-      fi
+      ])
       LIBS="$_save_LIBS"
     ])
-  fi
+  ])
 
-  if test "$ax_cv_lib_readline" != "no"; then
+  AS_IF([test "$ax_cv_lib_readline" != "no"], [
     READLINE_LIBS="$ax_cv_lib_readline"
     READLINE_CFLAGS="$ax_cv_lib_readline_cflags"
     AC_SUBST(READLINE_LIBS)
@@ -129,13 +129,13 @@ AC_DEFUN([AX_LIB_READLINE_LLDPD], [
       ax_cv_lib_readline_history="no"
       AC_TRY_LINK_FUNC(add_history, ax_cv_lib_readline_history="yes")
     ])
-    if test "$ax_cv_lib_readline_history" = "yes"; then
+    AS_IF([test "$ax_cv_lib_readline_history" = "yes"], [
       AC_DEFINE(HAVE_READLINE_HISTORY, 1,
                 [Define if your readline library has \`add_history'])
       AC_CHECK_HEADERS(history.h readline/history.h editline/history.h)
-    fi
+    ])
 
     LIBS="$_save_LIBS"
     CFLAGS="$_save_CFLAGS"
-  fi
+  ])
 ])dnl

--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -297,10 +297,10 @@ AC_DEFUN([DX_IF_FEATURE], [ifelse(DX_FEATURE_$1, ON, [$2], [$3])])
 # Require the specified program to be found for the DX_CURRENT_FEATURE to work.
 AC_DEFUN([DX_REQUIRE_PROG], [
 AC_PATH_TOOL([$1], [$2])
-if test "$DX_FLAG_[]DX_CURRENT_FEATURE$$1" = 1; then
+AS_IF([test "$DX_FLAG_[]DX_CURRENT_FEATURE$$1" = 1], [
     AC_MSG_WARN([$2 not found - will not DX_CURRENT_DESCRIPTION])
     AC_SUBST(DX_FLAG_[]DX_CURRENT_FEATURE, 0)
-fi
+])
 ])
 
 # DX_TEST_FEATURE(FEATURE)
@@ -343,35 +343,33 @@ AC_DEFUN([DX_ARG_ABLE], [
                                                       [--enable-doxygen-$1]),
                                   DX_IF_FEATURE([$1], [don't $2], [$2]))],
                   [
-case "$enableval" in
-#(
-y|Y|yes|Yes|YES)
+AS_CASE([$enableval],
+[y|Y|yes|Yes|YES], [
     AC_SUBST([DX_FLAG_$1], 1)
     $3
-;; #(
-n|N|no|No|NO)
+],
+[n|N|no|No|NO], [
     AC_SUBST([DX_FLAG_$1], 0)
-;; #(
-*)
+],
+[
     AC_MSG_ERROR([invalid value '$enableval' given to doxygen-$1])
-;;
-esac
+])
 ], [
 AC_SUBST([DX_FLAG_$1], [DX_IF_FEATURE([$1], 1, 0)])
 $4
 ])
-if DX_TEST_FEATURE([$1]); then
+AS_IF([DX_TEST_FEATURE([$1])], [
     $5
     :
-fi
+])
 AM_CONDITIONAL(DX_COND_$1, DX_TEST_FEATURE([$1]))
-if DX_TEST_FEATURE([$1]); then
+AS_IF([DX_TEST_FEATURE([$1])], [
     $6
     :
-else
+], [
     $7
     :
-fi
+])
 ])
 
 ## -------------- ##
@@ -495,27 +493,25 @@ DX_ARG_ABLE(pdf, [generate doxygen PDF documentation],
 
 # LaTeX generation for PS and/or PDF:
 AM_CONDITIONAL(DX_COND_latex, DX_TEST_FEATURE(ps) || DX_TEST_FEATURE(pdf))
-if DX_TEST_FEATURE(ps) || DX_TEST_FEATURE(pdf); then
+AS_IF([DX_TEST_FEATURE(ps) || DX_TEST_FEATURE(pdf)], [
     DX_ENV_APPEND(GENERATE_LATEX, YES)
-else
+], [
     DX_ENV_APPEND(GENERATE_LATEX, NO)
-fi
+])
 
 # Paper size for PS and/or PDF:
 AC_ARG_VAR(DOXYGEN_PAPER_SIZE,
            [a4wide (default), a4, letter, legal or executive])
-case "$DOXYGEN_PAPER_SIZE" in
-#(
-"")
+AS_CASE([$DOXYGEN_PAPER_SIZE],
+[""], [
     AC_SUBST(DOXYGEN_PAPER_SIZE, "")
-;; #(
-a4wide|a4|letter|legal|executive)
+],
+[a4wide|a4|letter|legal|executive], [
     DX_ENV_APPEND(PAPER_SIZE, $DOXYGEN_PAPER_SIZE)
-;; #(
-*)
+],
+[
     AC_MSG_ERROR([unknown DOXYGEN_PAPER_SIZE='$DOXYGEN_PAPER_SIZE'])
-;;
-esac
+])
 
 #For debugging:
 #echo DX_FLAG_doc=$DX_FLAG_doc

--- a/m4/config_subdirs.m4
+++ b/m4/config_subdirs.m4
@@ -8,7 +8,7 @@
 AC_DEFUN([lldp_CONFIG_SUBDIRS], [
   AC_CONFIG_SUBDIRS([$1])
   ac_dir="m4_normalize([$1])"
-  if test -f "$srcdir/$ac_dir/configure"; then
+  AS_IF([test -f "$srcdir/$ac_dir/configure"], [
     ac_sub_configure_args=
     ac_prev=
     eval "set x $ac_configure_args"
@@ -50,9 +50,9 @@ AC_DEFUN([lldp_CONFIG_SUBDIRS], [
     # Always prepend --prefix to ensure using the same prefix
     # in subdir configurations.
     ac_arg="--prefix=$prefix"
-    case $ac_arg in
-    *\'*) ac_arg=`AS_ECHO(["$ac_arg"]) | sed "s/'/'\\\\\\\\''/g"` ;;
-    esac
+    AS_CASE([$ac_arg],
+    [*\'*], [ac_arg=`AS_ECHO(["$ac_arg"]) | sed "s/'/'\\\\\\\\''/g"`]
+    )
     ac_sub_configure_args="'$ac_arg' $ac_sub_configure_args"
 
     # Always prepend --disable-option-checking to silence warnings, since
@@ -60,10 +60,10 @@ AC_DEFUN([lldp_CONFIG_SUBDIRS], [
     ac_sub_configure_args="--disable-option-checking $ac_sub_configure_args"
 
     # Silent rules
-    case $enable_silent_rules in
-      no)  ac_sub_configure_args="$ac_sub_configure_args --disable-silent-rules" ;;
-      *)   ac_sub_configure_args="$ac_sub_configure_args --enable-silent-rules" ;;
-    esac
+    AS_CASE([$enable_silent_rules],
+      [no],  [ac_sub_configure_args="$ac_sub_configure_args --disable-silent-rules"],
+      [ac_sub_configure_args="$ac_sub_configure_args --enable-silent-rules"]
+    )
 
     # Add additional options
     ac_sub_configure_args="$ac_sub_configure_args $2"
@@ -97,7 +97,7 @@ AC_DEFUN([lldp_CONFIG_SUBDIRS], [
     _AS_ECHO_LOG([$ac_msg])
     _AS_ECHO([$ac_msg])
     cd "$ac_popdir"
-  fi
+  ])
 ])
 
 # Dummy AC_CONFIG_SUBDIRS for autoreconf tracing

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -21,7 +21,7 @@ AC_DEFUN([gl_LD_VERSION_SCRIPT],
     AS_HELP_STRING([--enable-ld-version-script],
       [enable linker version script (default is enabled when possible)]),
       [have_ld_version_script=$enableval], [])
-  if test -z "$have_ld_version_script"; then
+  AS_IF([test -z "$have_ld_version_script"], [
     AC_MSG_CHECKING([if LD -Wl,--version-script works])
     save_LDFLAGS="$LDFLAGS"
     LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
@@ -30,7 +30,7 @@ foo
 EOF
     AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
                    [accepts_syntax_errors=yes], [accepts_syntax_errors=no])
-    if test "$accepts_syntax_errors" = no; then
+    AS_IF([test "$accepts_syntax_errors" = no], [
       cat > conftest.map <<EOF
 VERS_1 {
         global: sym;
@@ -42,12 +42,12 @@ VERS_2 {
 EOF
       AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
                      [have_ld_version_script=yes], [have_ld_version_script=no])
-    else
+    ], [
       have_ld_version_script=no
-    fi
+    ])
     rm -f conftest.map
     LDFLAGS="$save_LDFLAGS"
     AC_MSG_RESULT($have_ld_version_script)
-  fi
+  ])
   AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$have_ld_version_script" = "yes")
 ])

--- a/m4/libevent.m4
+++ b/m4/libevent.m4
@@ -9,9 +9,9 @@ AC_DEFUN([lldp_CHECK_LIBEVENT], [
       [--with-embedded-libevent],
       [Use embedded libevent @<:@default=auto@:>@]
   ), [], [with_embedded_libevent=auto])
-  if test x"$with_embedded_libevent" = x"yes"; then
+  AS_IF([test x"$with_embedded_libevent" = x"yes"], [
      LIBEVENT_EMBEDDED=1
-  else
+  ], [
     # If not forced, check first with pkg-config
     PKG_CHECK_MODULES([libevent], [libevent >= 2.0.5], [
        # Check if we have a working libevent
@@ -26,31 +26,31 @@ AC_DEFUN([lldp_CHECK_LIBEVENT], [
 @%:@include <event2/event.h>]], [[ struct event_base *base = event_base_new(); event_new(base, -1, 0, NULL, NULL); ]])],[
          AC_MSG_RESULT([yes])
        ],[
-         if test x"$with_embedded_libevent" = x"auto"; then
+         AS_IF([test x"$with_embedded_libevent" = x"auto"], [
            AC_MSG_RESULT([no, using shipped libevent])
            LIBEVENT_EMBEDDED=1
-         else
+         ], [
            AC_MSG_ERROR([*** unusable system libevent])
-         fi
+         ])
        ])
        CFLAGS="$_save_CFLAGS"
        LIBS="$_save_LIBS"
     ], [
       # No appropriate version, let's use the shipped copy if possible
-      if test x"$with_embedded_libevent" = x"auto"; then
+      AS_IF([test x"$with_embedded_libevent" = x"auto"], [
         AC_MSG_NOTICE([using shipped libevent])
         LIBEVENT_EMBEDDED=1
-      else
+      ], [
         AC_MSG_ERROR([*** libevent not found])
-      fi
+      ])
     ])
-  fi
+  ])
 
-  if test x"$LIBEVENT_EMBEDDED" != x; then
+  AS_IF([test x"$LIBEVENT_EMBEDDED" != x], [
     unset libevent_LIBS
     libevent_CFLAGS="-I\$(top_srcdir)/libevent/include -I\$(top_builddir)/libevent/include"
     libevent_LDFLAGS="\$(top_builddir)/libevent/libevent.la"
-  fi
+  ])
 
   # Call ./configure in libevent. Need it for make dist...
   libevent_configure_args="$libevent_configure_args --disable-libevent-regress"

--- a/m4/os.m4
+++ b/m4/os.m4
@@ -4,12 +4,11 @@
 # List of supported OS.
 #
 AC_DEFUN([lldp_DEFINE_OS], [dnl
-  case $host_os in
-    $1)
+  AS_CASE([$host_os],
+    [$1], [
       os="$2"
       AC_DEFINE_UNQUOTED(HOST_OS_$3, 1, [Host operating system is $2])
-      ;;
-  esac
+    ])
   AM_CONDITIONAL(HOST_OS_$3, test x"$os" = x"$2")dnl
 ])
 
@@ -25,10 +24,10 @@ AC_DEFUN([lldp_CHECK_OS], [
   lldp_DEFINE_OS(darwin*, macOS, OSX)
   lldp_DEFINE_OS(solaris*, Solaris, SOLARIS)
 
-  if test x"$os" = x; then
+  AS_IF([test x"$os" = x], [
      AC_MSG_RESULT(no)
      AC_MSG_ERROR([*** unsupported OS $host_os])
-  fi
+  ])
   AC_MSG_RESULT([yes ($os)])
 ])
 
@@ -37,17 +36,16 @@ AC_DEFUN([lldp_CFLAGS_OS], [
   # Most of what we want can be enabled nowadays with _GNU_SOURCE
   AX_CFLAGS_GCC_OPTION([-D_GNU_SOURCE], [LLDP_CPPFLAGS])    dnl GNU systems (asprintf, ...)
 
-  case $host_os in
-     solaris*)
+  AS_CASE([$host_os],
+     [solaris*], [
        AX_CFLAGS_GCC_OPTION([-D__EXTENSIONS__], [LLDP_CPPFLAGS]) dnl (CMSG_*)
        AX_CFLAGS_GCC_OPTION([-D_XPG4_2], [LLDP_CPPFLAGS])        dnl (CMSG_*)
-       ;;
-     hpux*)
+     ],
+     [hpux*], [
        AX_CFLAGS_GCC_OPTION([-D_XOPEN_SOURCE=500], [LLDP_CPPFLAGS])      dnl HP-UX
        AX_CFLAGS_GCC_OPTION([-D_XOPEN_SOURCE_EXTENDED], [LLDP_CPPFLAGS]) dnl HP-UX
-       ;;
-     netbsd*)
+     ],
+     [netbsd*], [
        AX_CFLAGS_GCC_OPTION([-D_OPENBSD_SOURCE], [LLDP_CPPFLAGS]) dnl strtonum
-       ;;
-  esac
+     ])
 ])

--- a/m4/progname.m4
+++ b/m4/progname.m4
@@ -9,7 +9,7 @@ AC_DEFUN([lldp_CHECK___PROGNAME],[
                      [ lldp_cv_check___progname="yes" ],
                      [ lldp_cv_check___progname="no" ])
   ])
-  if test x"$lldp_cv_check___progname" = x"yes"; then
+  AS_IF([test x"$lldp_cv_check___progname" = x"yes"], [
      AC_DEFINE([HAVE___PROGNAME], [1], [Define if libc defines __progname])
-  fi
+  ])
 ])

--- a/m4/seccomp.m4
+++ b/m4/seccomp.m4
@@ -3,7 +3,7 @@
 #
 
 AC_DEFUN([lldp_CHECK_SECCOMP], [
-   if test x"$with_seccomp" != x"no"; then
+   AS_IF([test x"$with_seccomp" != x"no"], [
       PKG_CHECK_MODULES([libseccomp], [libseccomp >= 1], [
          AC_SUBST([libseccomp_LIBS])
          AC_SUBST([libseccomp_CFLAGS])
@@ -15,5 +15,5 @@ AC_DEFUN([lldp_CHECK_SECCOMP], [
          fi
          with_seccomp=no
       ])
-   fi
+   ])
 ])

--- a/m4/snmp.m4
+++ b/m4/snmp.m4
@@ -2,15 +2,15 @@
 # lldp_CHECK_SNMP
 #
 AC_DEFUN([lldp_CHECK_SNMP], [
-  if test x"$with_snmp" != x"no"; then
+  AS_IF([test x"$with_snmp" != x"no"], [
    AC_PATH_TOOL([NETSNMP_CONFIG], [net-snmp-config], [no])
-   if test x"$NETSNMP_CONFIG" = x"no"; then
+   AS_IF([test x"$NETSNMP_CONFIG" = x"no"], [
       dnl No luck
-      if test x"$with_snmp" = x"yes"; then
+      AS_IF([test x"$with_snmp" = x"yes"], [
          AC_MSG_FAILURE([*** no NetSNMP support found])
-      fi
+      ])
       with_snmp=no
-   else
+   ], [
       dnl Check it is working as expected
       NETSNMP_LIBS=`${NETSNMP_CONFIG} --agent-libs`
       NETSNMP_CFLAGS=`${NETSNMP_CONFIG} --base-cflags`
@@ -56,27 +56,27 @@ int main(void);
             dnl Can we use snmp_select_info2?
             AC_CHECK_FUNCS([snmp_select_info2])
           ],[
-            if test x"$with_snmp" = x"yes"; then
+            AS_IF([test x"$with_snmp" = x"yes"], [
               AC_MSG_ERROR([*** no subagent support in net-snmp])
-            fi
+            ])
             with_snmp=no
           ])
         ],[
-          if test x"$with_snmp" = x"yes"; then
+          AS_IF([test x"$with_snmp" = x"yes"], [
             AC_MSG_ERROR([*** unable to use net-snmp])
-          fi
+          ])
           with_snmp=no
         ])
       ],[
         AC_MSG_RESULT(no)
-        if test x"$with_snmp" = x"yes"; then
+        AS_IF([test x"$with_snmp" = x"yes"], [
           AC_MSG_ERROR([*** incorrect CFLAGS from net-snmp-config])
-        fi
+        ])
         with_snmp=no
       ])
 
       CFLAGS="$_save_flags"
       LIBS="$_save_libs"
-   fi
-  fi
+   ])
+  ])
 ])

--- a/m4/stdint.m4
+++ b/m4/stdint.m4
@@ -3,11 +3,12 @@
 #
 AC_DEFUN([lldp_CHECK_STDINT], [
   AC_CHECK_TYPES([u_int32_t, uint32_t])
-  if test "_$ac_cv_type_uint32_t" = _yes; then
-  if test "_$ac_cv_type_u_int32_t" = _no; then
+  AS_IF([test "_$ac_cv_type_uint32_t" = _yes], [
+   AS_IF([test "_$ac_cv_type_u_int32_t" = _no], [
     AC_DEFINE(u_int8_t, uint8_t, [Compatibility with Linux u_int8_t])
     AC_DEFINE(u_int16_t, uint16_t, [Compatibility with Linux u_int16_t])
     AC_DEFINE(u_int32_t, uint32_t, [Compatibility with Linux u_int32_t])
     AC_DEFINE(u_int64_t, uint64_t, [Compatibility with Linux u_int64_t])
-  fi
-  fi])
+   ])
+  ])
+])

--- a/m4/systemtap.m4
+++ b/m4/systemtap.m4
@@ -7,11 +7,11 @@ AC_DEFUN([lldp_SYSTEMTAP], [
   # Enable systemtap support
   lldp_ARG_ENABLE([dtrace], [systemtap/DTrace trace support], [no])
   AM_CONDITIONAL([ENABLE_SYSTEMTAP], [test x"$enable_dtrace" = x"yes"])
-  if test x"$enable_dtrace" = x"yes"; then
+  AS_IF([test x"$enable_dtrace" = x"yes"], [
      AC_CHECK_PROGS(DTRACE, dtrace)
-     if test -z "$DTRACE"; then
+     AS_IF([test -z "$DTRACE"], [
        AC_MSG_ERROR([*** dtrace command not found])
-     fi
+     ])
      AC_CHECK_HEADER([sys/sdt.h],,[AC_MSG_ERROR([*** no sys/sdt.h header found])])
-  fi
+  ])
 ])

--- a/m4/xml2.m4
+++ b/m4/xml2.m4
@@ -4,7 +4,7 @@
 
 
 AC_DEFUN([lldp_CHECK_XML2], [
-  if test x"$with_xml" != x"no"; then
+  AS_IF([test x"$with_xml" != x"no"], [
    PKG_CHECK_MODULES([libxml2], [libxml-2.0], [
     dnl Found through pkg-config
     AC_DEFINE_UNQUOTED([USE_XML], 1, [Define to indicate to enable XML support])
@@ -12,13 +12,13 @@ AC_DEFUN([lldp_CHECK_XML2], [
    ],[
     dnl Fallback to xml2-config
     AC_PATH_TOOL([XML2_CONFIG], [xml2-config], [no])
-    if test x"$XML2_CONFIG" = x"no"; then
+    AS_IF([test x"$XML2_CONFIG" = x"no"], [
       dnl No luck
-      if test x"$with_xml" = x"yes"; then
+      AS_IF([test x"$with_xml" = x"yes"], [
          AC_MSG_FAILURE([*** no libxml2 support found])
-      fi
+      ])
       with_xml=no
-    else
+    ], [
       dnl Check that it's working as expected
       libxml2_LIBS=`${XML2_CONFIG} --libs`
       libxml2_CFLAGS=`${XML2_CONFIG} --cflags`
@@ -43,14 +43,14 @@ AC_DEFUN([lldp_CHECK_XML2], [
         with_xml=yes
       ],[
         AC_MSG_RESULT(no)
-        if test x"$with_xml" = x"yes"; then
+        AS_IF([test x"$with_xml" = x"yes"], [
             AC_MSG_FAILURE([*** libxml2 not working as expected])
-        fi
+        ])
         with_xml=no
       ])
       CFLAGS="$_save_flags"
       LIBS="$_save_libs"
-    fi
+    ])
    ])
-  fi
+  ])
 ])


### PR DESCRIPTION
This fixes an issue where when using the options

  `--without-embedded-libevent --without-libbsd`

configure errors out with missing libevent:
```
checking for libevent >= 2.0.5... no
configure: error: *** libevent not found
```
but succeeds to find libevent when using

  `--without-embedded-libevent --with-libbsd`

configure options instead.
See also: https://autotools.info/autoconf/m4sh.html