### PR TITLE
fix: Add lldpctl.hpp to the include list

### DIFF
--- a/redhat/lldpd.spec
+++ b/redhat/lldpd.spec
@@ -314,6 +314,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/liblldpctl.a
 %{_libdir}/pkgconfig/lldpctl.pc
 %{_includedir}/lldpctl.h
+%{_includedir}/lldpctl.hpp
 %{_includedir}/lldp-const.h
 
 %changelog

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = $(LLDP_CPPFLAGS)
 AM_LDFLAGS = $(LLDP_LDFLAGS)
 
 lib_LTLIBRARIES = liblldpctl.la
-include_HEADERS = lldpctl.h
+include_HEADERS = lldpctl.h lldpctl.hpp
 
 noinst_LTLIBRARIES = libfixedpoint.la
 libfixedpoint_la_SOURCES = fixedpoint.h fixedpoint.c


### PR DESCRIPTION
The C++ wrapper `lldpctl.hpp` must be added to the include file list so that it can be used.