### PR TITLE
Tx fast start neighbor deletion reason

### DIFF
--- a/src/client/conf-med.c
+++ b/src/client/conf-med.c
@@ -489,11 +489,8 @@ register_commands_configure_med(struct cmd_node *configure,
 
 	struct cmd_node *configure_med =
 	    commands_new(configure, "med", "MED configuration", NULL, NULL, NULL);
-	struct cmd_node *unconfigure_med =
-	    commands_new(unconfigure, "med", "MED configuration", NULL, NULL, NULL);
 
 	register_commands_medloc(configure_med);
 	register_commands_medpol(configure_med);
 	register_commands_medpow(configure_med);
-	register_commands_medfast(configure_med, unconfigure_med);
 }

--- a/src/client/conf-med.c
+++ b/src/client/conf-med.c
@@ -416,68 +416,6 @@ register_commands_medpol(struct cmd_node *configure_med)
 	}
 }
 
-static int
-cmd_faststart(struct lldpctl_conn_t *conn, struct writer *w, struct cmd_env *env,
-    const void *arg)
-{
-	log_debug("lldpctl", "configure fast interval support");
-
-	lldpctl_atom_t *config = lldpctl_get_configuration(conn);
-	if (config == NULL) {
-		log_warnx("lldpctl", "unable to get configuration from lldpd. %s",
-		    lldpctl_last_strerror(conn));
-		return 0;
-	}
-
-	const char *action = arg;
-	if ((!strcmp(action, "enable") &&
-		(lldpctl_atom_set_int(config, lldpctl_k_config_fast_start_enabled, 1) ==
-		    NULL)) ||
-	    (!strcmp(action, "disable") &&
-		(lldpctl_atom_set_int(config, lldpctl_k_config_fast_start_enabled, 0) ==
-		    NULL)) ||
-	    (!strcmp(action, "delay") &&
-		(lldpctl_atom_set_str(config, lldpctl_k_config_fast_start_interval,
-		     cmdenv_get(env, "tx-interval")) == NULL))) {
-		log_warnx("lldpctl", "unable to setup fast start. %s",
-		    lldpctl_last_strerror(conn));
-		lldpctl_atom_dec_ref(config);
-		return 0;
-	}
-	log_info("lldpctl", "configuration for fast start applied");
-	lldpctl_atom_dec_ref(config);
-	return 1;
-}
-
-/**
- * Register "configure med fast-start *"
- */
-static void
-register_commands_medfast(struct cmd_node *med, struct cmd_node *nomed)
-{
-	struct cmd_node *configure_fast = commands_new(med, "fast-start",
-	    "Fast start configuration", cmd_check_no_env, NULL, "ports");
-	struct cmd_node *unconfigure_fast = commands_new(nomed, "fast-start",
-	    "Fast start configuration", cmd_check_no_env, NULL, "ports");
-
-	/* Enable */
-	commands_new(commands_new(configure_fast, "enable", "Enable fast start", NULL,
-			 NULL, NULL),
-	    NEWLINE, "Enable fast start", NULL, cmd_faststart, "enable");
-
-	/* Set TX delay */
-	commands_new(commands_new(commands_new(configure_fast, "tx-interval",
-				      "Set LLDP fast transmit delay", NULL, NULL, NULL),
-			 NULL, "LLDP fast transmit delay in seconds", NULL,
-			 cmd_store_env_value, "tx-interval"),
-	    NEWLINE, "Set LLDP fast transmit delay", NULL, cmd_faststart, "delay");
-
-	/* Disable */
-	commands_new(commands_new(unconfigure_fast, NEWLINE, "Disable fast start", NULL,
-			 cmd_faststart, "disable"),
-	    NEWLINE, "Disable fast start", NULL, cmd_faststart, "disable");
-}
-
 /**
  * Register "configure med *"
  */

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -970,6 +970,14 @@ display_configuration(lldpctl_conn_t *conn, struct writer *w)
 	tag_start(w, "configuration", "Global configuration");
 	tag_start(w, "config", "Configuration");
 
+	tag_datatag(w, "fast-start", "Fast start mechanism",
+	    (lldpctl_atom_get_int(configuration, lldpctl_k_config_fast_start_enabled) ==
+		0) ?
+		"no" :
+		"yes");
+	tag_datatag(w, "fast-start-interval", "Fast start interval",
+	    N(lldpctl_atom_get_str(configuration,
+		lldpctl_k_config_fast_start_interval)));
 	tag_datatag(w, "tx-delay", "Transmit delay",
 	    lldpctl_atom_get_str(configuration, lldpctl_k_config_tx_interval));
 	tag_datatag(w, "tx-delay-ms", "Transmit delay in milliseconds",
@@ -1019,14 +1027,6 @@ display_configuration(lldpctl_conn_t *conn, struct writer *w)
 		 lldpctl_k_config_lldpmed_noinventory) == 0) ?
 		"no" :
 		"yes");
-	tag_datatag(w, "lldpmed-faststart", "LLDP-MED fast start mechanism",
-	    (lldpctl_atom_get_int(configuration, lldpctl_k_config_fast_start_enabled) ==
-		0) ?
-		"no" :
-		"yes");
-	tag_datatag(w, "lldpmed-faststart-interval", "LLDP-MED fast start interval",
-	    N(lldpctl_atom_get_str(configuration,
-		lldpctl_k_config_fast_start_interval)));
 	tag_datatag(w, "bond-slave-src-mac-type",
 	    "Source MAC for LLDP frames on bond slaves",
 	    lldpctl_atom_get_str(configuration,

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -666,15 +666,15 @@ and subtype
 is specified, remove specific instances of custom TLV.
 .Ed
 
-.Cd configure med fast-start
+.Cd configure lldp fast-start
 .Cd enable | tx-interval Ar interval
 .Bd -ragged -offset XXXXXX
-Configure LLDP-MED fast start mechanism. When a new LLDP-MED-enabled
+Configure LLDP fast start mechanism. When a new LLDP
 neighbor is detected, fast start allows
 .Nm lldpd
 to shorten the interval between two LLDPDU.
 .Cd enable
-should enable LLDP-MED fast start while
+should enable LLDP fast start while
 .Cd tx-interval
 specifies the interval between two LLDPDU in seconds. The valid interval
 range is 1 through 3600 in seconds. The default interval is 1 second. Once
@@ -682,9 +682,9 @@ range is 1 through 3600 in seconds. The default interval is 1 second. Once
 neighbor is detected.
 .Ed
 
-.Cd unconfigure med fast-start
+.Cd unconfigure lldp fast-start
 .Bd -ragged -offset XXXXXX
-Disable LLDP-MED fast start mechanism.
+Disable LLDP fast start mechanism.
 .Ed
 
 .Cd configure

--- a/src/client/show.c
+++ b/src/client/show.c
@@ -205,7 +205,7 @@ watchcb(lldpctl_change_t type, lldpctl_atom_t *interface, lldpctl_atom_t *neighb
 		tag_start(w, "lldp-deleted-timeout", "LLDP neighbor deleted (timeout)");
 		break;
 	case lldpctl_c_deleted_admin:
-		tag_start(w, "lldp-deleted-admin", "LLDP neighbor deleted (admin config change)");
+		tag_start(w, "lldp-deleted-admin", "LLDP neighbor deleted (interface pattern)");
 		break;
 	default:
 		return;

--- a/src/client/show.c
+++ b/src/client/show.c
@@ -189,9 +189,11 @@ watchcb(lldpctl_change_t type, lldpctl_atom_t *interface, lldpctl_atom_t *neighb
 	}
 
 	switch (type) {
+#if 0
 	case lldpctl_c_deleted:
 		tag_start(w, "lldp-deleted", "LLDP neighbor deleted");
 		break;
+#endif
 	case lldpctl_c_updated:
 		tag_start(w, "lldp-updated", "LLDP neighbor updated");
 		break;

--- a/src/client/show.c
+++ b/src/client/show.c
@@ -198,6 +198,15 @@ watchcb(lldpctl_change_t type, lldpctl_atom_t *interface, lldpctl_atom_t *neighb
 	case lldpctl_c_added:
 		tag_start(w, "lldp-added", "LLDP neighbor added");
 		break;
+	case lldpctl_c_deleted_signoff:
+		tag_start(w, "lldp-deleted-signoff", "LLDP neighbor deleted (signoff)");
+		break;
+	case lldpctl_c_deleted_timeout:
+		tag_start(w, "lldp-deleted-timeout", "LLDP neighbor deleted (timeout)");
+		break;
+	case lldpctl_c_deleted_admin:
+		tag_start(w, "lldp-deleted-admin", "LLDP neighbor deleted (admin config change)");
+		break;
 	default:
 		return;
 	}

--- a/src/daemon/agent.c
+++ b/src/daemon/agent.c
@@ -1801,6 +1801,18 @@ agent_notify(struct lldpd_hardware *hardware, int type, struct lldpd_port *rport
 		log_debug("snmp", "send notification for neighbor added on %s",
 		    hardware->h_ifname);
 		break;
+	case NEIGHBOR_CHANGE_DELETED_SIGNOFF:
+		log_debug("snmp", "send notification for neighbor deleted on %s due to signoff",
+		    hardware->h_ifname);
+		break;
+	case NEIGHBOR_CHANGE_DELETED_TIMEOUT:
+		log_debug("snmp", "send notification for neighbor deleted on %s due to timeout",
+		    hardware->h_ifname);
+		break;
+	case NEIGHBOR_CHANGE_DELETED_ADMIN:
+		log_debug("snmp", "send notification for neighbor deleted on %s due to admin config change",
+		    hardware->h_ifname);
+		break;
 	}
 
 	TAILQ_FOREACH (h, &hardware->h_cfg->g_hardware, h_entries) {
@@ -1824,7 +1836,7 @@ agent_notify(struct lldpd_hardware *hardware, int type, struct lldpd_port *rport
 	snmp_varlist_add_variable(&notification_vars, ageouts_oid, ageouts_oid_len,
 	    ASN_GAUGE, (u_char *)&ageouts, sizeof(ageouts));
 
-	if (type != NEIGHBOR_CHANGE_DELETED) {
+	if (type == NEIGHBOR_CHANGE_UPDATED || type == NEIGHBOR_CHANGE_ADDED) {
 		snmp_varlist_add_variable(&notification_vars, locport_oid,
 		    locport_oid_len, ASN_OCTET_STR, (u_char *)hardware->h_ifname,
 		    strnlen(hardware->h_ifname, IFNAMSIZ));

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -123,7 +123,6 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 		levent_send_now(cfg);
 	}
 
-#ifdef ENABLE_LLDPMED
 	if (CHANGED(c_enable_fast_start)) {
 		cfg->g_config.c_enable_fast_start = config->c_enable_fast_start;
 		log_debug("rpc", "client asked to %s fast start",
@@ -134,7 +133,6 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type, void *i
 		    config->c_tx_fast_interval);
 		cfg->g_config.c_tx_fast_interval = config->c_tx_fast_interval;
 	}
-#endif
 	if (CHANGED_STR(c_iface_pattern)) {
 		log_debug("rpc", "change interface pattern to %s",
 		    config->c_iface_pattern ? config->c_iface_pattern : "(NULL)");

--- a/src/daemon/event.c
+++ b/src/daemon/event.c
@@ -812,12 +812,10 @@ levent_send_pdu(evutil_socket_t fd, short what, void *arg)
 	log_debug("event", "trigger sending PDU for port %s", hardware->h_ifname);
 	lldpd_send(hardware);
 
-#ifdef ENABLE_LLDPMED
 	if (hardware->h_tx_fast > 0) hardware->h_tx_fast--;
 
 	if (hardware->h_tx_fast > 0)
 		tx_interval = hardware->h_cfg->g_config.c_tx_fast_interval * 1000;
-#endif
 
 	struct timeval tv;
 	tv.tv_sec = tx_interval / 1000;

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -363,13 +363,15 @@ lldpd_count_neighbors(struct lldpd *cfg)
 }
 
 static void
-notify_clients_deletion(struct lldpd_hardware *hardware, struct lldpd_port *rport)
+notify_clients_deletion(struct lldpd_hardware *hardware, struct lldpd_port *rport, int state)
 {
 	TRACE(LLDPD_NEIGHBOR_DELETE(hardware->h_ifname, rport->p_chassis->c_name,
 	    rport->p_descr));
 	levent_ctl_notify(hardware->h_ifname, NEIGHBOR_CHANGE_DELETED, rport);
+	levent_ctl_notify(hardware->h_ifname, state, rport);
 #ifdef USE_SNMP
 	agent_notify(hardware, NEIGHBOR_CHANGE_DELETED, rport);
+	agent_notify(hardware, state, rport);
 #endif
 }
 

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -740,8 +740,7 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 #endif
 	}
 
-#ifdef ENABLE_LLDPMED
-	if (!oport && port->p_chassis->c_med_type) {
+	if (!oport) {
 		/* New neighbor, fast start */
 		if (hardware->h_cfg->g_config.c_enable_fast_start &&
 		    !hardware->h_tx_fast) {
@@ -754,7 +753,6 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 
 		levent_schedule_pdu(hardware);
 	}
-#endif
 
 	return;
 }
@@ -1571,8 +1569,8 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	int i, found, advertise_version = 1;
 #ifdef ENABLE_LLDPMED
 	int lldpmed = 0, noinventory = 0;
-	int enable_fast_start = 1;
 #endif
+	int enable_fast_start = 1;
 	char *descr_override = NULL;
 	char *platform_override = NULL;
 	char *lsb_release = NULL;
@@ -1935,11 +1933,9 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	cfg->g_config.c_ttl = cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold;
 	cfg->g_config.c_ttl = MIN((cfg->g_config.c_ttl + 999) / 1000, 65535);
 	cfg->g_config.c_max_neighbors = LLDPD_MAX_NEIGHBORS;
-#ifdef ENABLE_LLDPMED
 	cfg->g_config.c_enable_fast_start = enable_fast_start;
 	cfg->g_config.c_tx_fast_init = LLDPD_FAST_INIT;
 	cfg->g_config.c_tx_fast_interval = LLDPD_FAST_TX_INTERVAL;
-#endif
 #ifdef USE_SNMP
 	cfg->g_snmp = snmp;
 	cfg->g_snmp_agentx = agentx;

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = $(LLDP_CPPFLAGS)
 AM_LDFLAGS = $(LLDP_LDFLAGS)
 
 lib_LTLIBRARIES = liblldpctl.la
-include_HEADERS = lldpctl.h
+include_HEADERS = lldpctl.h lldpctl.hpp
 
 noinst_LTLIBRARIES = libfixedpoint.la
 libfixedpoint_la_SOURCES = fixedpoint.h fixedpoint.c

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -233,11 +233,11 @@ _lldpctl_atom_get_int_config(lldpctl_atom_t *atom, lldpctl_key_t key)
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_lldpmed_noinventory:
 		return c->config->c_noinventory;
+#endif
 	case lldpctl_k_config_fast_start_enabled:
 		return c->config->c_enable_fast_start;
 	case lldpctl_k_config_fast_start_interval:
 		return c->config->c_tx_fast_interval;
-#endif
 	case lldpctl_k_config_tx_hold:
 		return c->config->c_tx_hold;
 	case lldpctl_k_config_max_neighbors:
@@ -284,7 +284,6 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key, long int v
 	case lldpctl_k_config_chassis_mgmt_advertise:
 		config.c_mgmt_advertise = c->config->c_mgmt_advertise = value;
 		break;
-#ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_fast_start_enabled:
 		config.c_enable_fast_start = c->config->c_enable_fast_start = value;
 		break;
@@ -292,7 +291,6 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key, long int v
 		config.c_tx_fast_interval = value;
 		if (value > 0 && value <= 3600) c->config->c_tx_fast_interval = value;
 		break;
-#endif
 	case lldpctl_k_config_tx_hold:
 		config.c_tx_hold = value;
 		if (value > 0 && value <= 100) c->config->c_tx_hold = value;

--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -225,17 +225,9 @@ check_for_notification(lldpctl_conn_t *conn)
 
 	/* We have a notification, call the callback */
 	if (conn->watch_cb || conn->watch_cb2) {
-		switch (change->state) {
-		case NEIGHBOR_CHANGE_DELETED:
-			type = lldpctl_c_deleted;
-			break;
-		case NEIGHBOR_CHANGE_ADDED:
-			type = lldpctl_c_added;
-			break;
-		case NEIGHBOR_CHANGE_UPDATED:
-			type = lldpctl_c_updated;
-			break;
-		default:
+		if (change->state >= NEIGHBOR_CHANGE_MIN && change->state <= NEIGHBOR_CHANGE_MAX)
+			type = (lldpctl_change_t)(change->state + 1);
+		else {
 			log_warnx("control", "unknown notification type (%d)",
 			    change->state);
 			goto end;

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -454,9 +454,12 @@ void lldpctl_atom_dec_ref(lldpctl_atom_t *atom);
  * @see lldpctl_watch_callback2
  */
 typedef enum {
-	lldpctl_c_deleted, /**< The neighbor has been deleted */
+	lldpctl_c_deleted, /**< [deprecated] The neighbor has been deleted, possibly followed by an @c lldpctl_c_deleted_* entry below */
 	lldpctl_c_updated, /**< The neighbor has been updated */
 	lldpctl_c_added,   /**< This is a new neighbor */
+	lldpctl_c_deleted_signoff, /**< The neighbor has been deleted since it sent a signoff LLDP PDU (with TTL=0) */
+	lldpctl_c_deleted_timeout, /**< The neighbor has been deleted since its LLDP PDU's TTL timed out */
+	lldpctl_c_deleted_admin, /**< The neighbor has been deleted since the the corresponding port has been removed from the interface pattern */
 } lldpctl_change_t;
 
 /**

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -554,7 +554,7 @@ MARSHAL_END(lldpd_neighbor_change);
 void lldpd_chassis_mgmt_cleanup(struct lldpd_chassis *);
 void lldpd_chassis_cleanup(struct lldpd_chassis *, int);
 void lldpd_remote_cleanup(struct lldpd_hardware *,
-    void (*expire)(struct lldpd_hardware *, struct lldpd_port *), int);
+    void (*expire)(struct lldpd_hardware *, struct lldpd_port *, int), int);
 void lldpd_port_cleanup(struct lldpd_port *, int);
 void lldpd_config_cleanup(struct lldpd_config *);
 #ifdef ENABLE_DOT1

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -534,9 +534,14 @@ MARSHAL_TQ(lldpd_interface_list, lldpd_interface);
 
 struct lldpd_neighbor_change {
 	char *ifname;
+#define NEIGHBOR_CHANGE_MIN -1
 #define NEIGHBOR_CHANGE_DELETED -1
-#define NEIGHBOR_CHANGE_ADDED 1
 #define NEIGHBOR_CHANGE_UPDATED 0
+#define NEIGHBOR_CHANGE_ADDED 1
+#define NEIGHBOR_CHANGE_DELETED_SIGNOFF 2
+#define NEIGHBOR_CHANGE_DELETED_TIMEOUT 3
+#define NEIGHBOR_CHANGE_DELETED_ADMIN 4
+#define NEIGHBOR_CHANGE_MAX 4
 	int state;
 	struct lldpd_port *neighbor;
 };

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -410,10 +410,10 @@ struct lldpd_config {
 
 #ifdef ENABLE_LLDPMED
 	int c_noinventory;	 /* Don't send inventory with LLDP-MED */
+#endif
 	int c_enable_fast_start; /* enable fast start */
 	int c_tx_fast_init;	 /* Num of lldpd lldppdu's for fast start */
 	int c_tx_fast_interval;	 /* Time intr between sends during fast start */
-#endif
 	int c_tx_hold;		       /* Transmit hold */
 	int c_bond_slave_src_mac_type; /* Src mac type in lldp frames over bond
 					  slaves */
@@ -501,9 +501,7 @@ struct lldpd_hardware {
 	struct lldpd_port h_lport;	   /* Port attached to this hardware port */
 	TAILQ_HEAD(, lldpd_port) h_rports; /* Remote ports */
 
-#ifdef ENABLE_LLDPMED
 	int h_tx_fast; /* current tx fast start count */
-#endif
 };
 MARSHAL_BEGIN(lldpd_hardware)
 MARSHAL_IGNORE(lldpd_hardware, h_entries.tqe_next)

--- a/tests/integration/test_lldpcli.py
+++ b/tests/integration/test_lldpcli.py
@@ -690,24 +690,8 @@ def test_return_code(lldpd1, lldpcli, namespaces):
         ("configure lldp tx-interval 20", "tx-delay", 20),
         ("configure lldp tx-hold 5", "tx-hold", 5),
         ("configure lldp portidsubtype ifname", "lldp-portid-type", "ifname"),
-        pytest.param(
-            "unconfigure med fast-start",
-            "lldpmed-faststart",
-            "no",
-            marks=pytest.mark.skipif(
-                "'LLDP-MED' not in config.lldpd.features",
-                reason="LLDP-MED not supported",
-            ),
-        ),
-        pytest.param(
-            "configure med fast-start tx-interval 2",
-            "lldpmed-faststart-interval",
-            2,
-            marks=pytest.mark.skipif(
-                "'LLDP-MED' not in config.lldpd.features",
-                reason="LLDP-MED not supported",
-            ),
-        ),
+        ("unconfigure lldp fast-start", "fast-start", "no"),
+        ("configure lldp fast-start tx-interval 2", "fast-start-interval", 2),
         ("configure system interface pattern eth*", "iface-pattern", "eth*"),
         ("configure system interface permanent eth*", "perm-iface-pattern", "eth*"),
         ("configure system ip management pattern 10.*", "mgmt-pattern", "10.*"),

--- a/tests/lldpcli.conf
+++ b/tests/lldpcli.conf
@@ -39,11 +39,11 @@ configure lldp custom-tlv add oui 33,44,55 subtype 55 oui-info 65,65,65,65,65
 configure lldp custom-tlv replace oui 33,44,55 subtype 44 oui-info 66,66,66,66,66
 unconfigure lldp custom-tlv oui 33,44,55 subtype 55
 unconfigure lldp custom-tlv
+configure lldp fast-start enable
+configure lldp fast-start tx-interval 3
+unconfigure lldp fast-start
 configure system bond-slave-src-mac-type fixed
 configure system bond-slave-src-mac-type local
-configure med fast-start enable
-configure med fast-start tx-interval 3
-unconfigure med fast-start
 configure med location coordinate latitude 48.58667N longitude 2.2014E altitude 117.47 m datum WGS84
 configure med location address country US language en_US street "Commercial Road" city "Roseville"
 configure med location elin 911


### PR DESCRIPTION
This is the draft PR for #707.
To be discussed:
- If `lldpctl_c_deleted` event shall be kept for backward compatibility:
  - Add build parameter to build with support for either only `lldpctl_c_deleted` or for `lldpctl_c_deleted_signoff`, `lldpctl_c_deleted_timeout` and `lldpctl_c_deleted_admin`?
  - Deliver both `lldpctl_c_deleted` and the more specific event `lldpctl_c_deleted_signoff`, `lldpctl_c_deleted_timeout` or `lldpctl_c_deleted_admin`?
    - Let `lldpcli` ignore `lldpctl_c_deleted` as it expects a more specific event anyway?
  - Tag `lldpctl_c_deleted` as deprecated?
- If backward compatibility is not required then simply replace `lldpctl_c_deleted` by `lldpctl_c_deleted_signoff`, `lldpctl_c_deleted_timeout` and `lldpctl_c_deleted_admin`.

Any feedback is highly appreciated.