### PR TITLE
man: Amend keyword colour formatted as operations and not values.

### DIFF
--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -1078,11 +1078,11 @@ provider). This configuration is distinct from the configuration of the
 transmission of the LLDP-MED POE-MDI TLV but the user should ensure
 the coherency of those two configurations if they are used together.
 .Pp
-.Ar supported
+.Sy supported
 means that MDI power is supported on the given port while
-.Ar enabled
+.Sy enabled
 means that MDI power is enabled.
-.Ar paircontrol
+.Sy paircontrol
 is used to indicate whether pair selection can be controlled. Valid values
 for
 .Ar powerpairs


### PR DESCRIPTION
the keywords `supported` etc should be red here:

![Screenshot 2025-03-25 at 23 23 33](https://github.com/user-attachments/assets/06d546ab-9b32-4f5c-b857-a97ee2b68785)
