### PR TITLE
build: Fix macos compile warning on macos >= 12

### DIFF
--- a/src/daemon/dmi-osx.c
+++ b/src/daemon/dmi-osx.c
@@ -34,7 +34,8 @@ dmi_get(const char *classname, CFStringRef property)
 		    classname);
 		goto end;
 	}
-	service = IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+	// 0 here (previously kIOMasterPortDefault) indicates "use the default":
+	service = IOServiceGetMatchingService(0, matching);
 	if (!service) {
 		log_warnx("localchassis", "cannot get matching %s class from registry",
 		    classname);


### PR DESCRIPTION
dmi-osx.c:37:40: warning: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
        service = IOServiceGetMatchingService(kIOMasterPortDefault, matching);
                                              ^~~~~~~~~~~~~~~~~~~~
                                              kIOMainPortDefault