### PR TITLE
daemon/priv: fix PACKET_IGNORE_OUTGOING

### DIFF
--- a/include/linux/if_packet.h
+++ b/include/linux/if_packet.h
@@ -57,6 +57,7 @@ struct sockaddr_ll {
 #define PACKET_QDISC_BYPASS		20
 #define PACKET_ROLLOVER_STATS		21
 #define PACKET_FANOUT_DATA		22
+#define PACKET_IGNORE_OUTGOING		23
 
 #define PACKET_FANOUT_HASH		0
 #define PACKET_FANOUT_LB		1

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <regex.h>
 #include <sys/ioctl.h>
-#include <netpacket/packet.h> /* For sockaddr_ll */
 #if defined(__clang__)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wdocumentation"
@@ -34,6 +33,7 @@
 #include <linux/filter.h> /* For BPF filtering */
 #include <linux/sockios.h>
 #include <linux/if_ether.h>
+#include <linux/if_packet.h>
 #include <linux/ethtool.h>
 #if defined(__clang__)
 #  pragma clang diagnostic pop


### PR DESCRIPTION
Switch from netpacket/packet.h to linux/if_packet.h to pick up both sockaddr_ll and PACKET_IGNORE_OUTGOING.

Fixes case where PACKET_IGNORE_OUTGOING was compiled out due to ifdef conditional, which caused Linux zerocopy to break.

Fixes #732