### PR TITLE
C++ wrapper supports any unix-domain socket

### DIFF
--- a/src/lib/lldpctl.hpp
+++ b/src/lib/lldpctl.hpp
@@ -314,7 +314,9 @@ class LldpAtom {
  */
 class LldpCtl {
     public:
-	explicit LldpCtl()
+	explicit LldpCtl(std::string_view ctlname = ::lldpctl_get_default_transport())
+		: conn_ { ::lldpctl_new_name(ctlname.data(), nullptr, nullptr, this),
+			&::lldpctl_release }
 	{
 		if (!conn_) {
 			throw std::system_error(std::error_code(LLDPCTL_ERR_NOMEM,
@@ -422,8 +424,7 @@ class LldpCtl {
 	}
 
     private:
-	std::shared_ptr<lldpctl_conn_t> conn_ { ::lldpctl_new(nullptr, nullptr, this),
-		&::lldpctl_release };
+	std::shared_ptr<lldpctl_conn_t> conn_;
 };
 
 /**


### PR DESCRIPTION
The C++ wrapper `LldpCtl` only supports the default unix socket. When running several instances of `lldpd`, e.g. in separate network namespaces, we need to provide the unix socket to the `LldlCtl` client.

This PR adds a constructor to `LldpCtl` that takes a unix socket path as argument, which uses `lldpctl_new_name()` instead of `lldpctl_new()`.