### PR TITLE
daemon/interfaces: fix double-free when unable to initialize interface

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 lldpd (1.0.20)
  * Fix:
    + Do not break zero-copy traffic on Linux (#732 and #733)
+   + Fix crash on rapid addition/removal of interfaces (#744)
 
 lldpd (1.0.19)
  * Changes:

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -668,6 +668,7 @@ interfaces_helper_physical(struct lldpd *cfg, struct interfaces_device_list *int
 				    hardware->h_ifname);
 				if (hardware->h_ops && hardware->h_ops->cleanup) {
 					hardware->h_ops->cleanup(cfg, hardware);
+					hardware->h_ops = NULL;
 					levent_hardware_release(hardware);
 					levent_hardware_init(hardware);
 				}
@@ -675,7 +676,6 @@ interfaces_helper_physical(struct lldpd *cfg, struct interfaces_device_list *int
 			if (init(cfg, hardware) != 0) {
 				log_warnx("interfaces", "unable to initialize %s",
 				    hardware->h_ifname);
-				lldpd_hardware_cleanup(cfg, hardware);
 				continue;
 			}
 			hardware->h_ops = ops;


### PR DESCRIPTION
When an interface is converted from one type to another and cannot be initialized, we free it twice: once on the error and again when removing unused interfaces.

Remove the first occurrence and ensure we get in a state where the interface can be both cleaned up or reinstantiated in a later round.

Fix #744 