### PR TITLE
client: add vendor-specific organizational TLV display

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+lldpd (1.0.23)
+ * Changes:
+   + Add vendor-specific organizational TLV display via config files and code handlers
+     - Config files in SYSCONFDIR/lldpd.d/org-tlvs.conf.d/*.conf define how to interpret TLV payloads
+     - Supported field types: uint8, uint16, uint32, string, ipv4, mac, hex
+     - Code handlers for complex TLVs (e.g. Cisco ACI SubType 207)
+     - Ships with Cisco and Juniper TLV definitions
+     - Client-side only, no daemon changes
+
 lldpd (1.0.22)
  * Fix:
    + Fix out-of-bound read access when removing VLAN tag (CVE-2026-46433, #787)

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I $(top_srcdir)/include $(LLDP_CFLAGS)
-AM_CPPFLAGS = $(LLDP_CPPFLAGS)
+AM_CPPFLAGS = $(LLDP_CPPFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 AM_LDFLAGS = $(LLDP_LDFLAGS)
 
 sbin_PROGRAMS = lldpcli
@@ -18,7 +18,9 @@ lldpcli_SOURCES  = client.h lldpcli.c display.c \
 	commands.c show.c \
 	misc.c tokenizer.c \
 	utf8.c \
-	writer.h text_writer.c kv_writer.c json_writer.c
+	writer.h text_writer.c kv_writer.c json_writer.c \
+	org_tlv_handler.h org_tlv_handler.c org_tlv_handler_cisco.c \
+	org_tlv_conf.h org_tlv_conf.c
 lldpcli_LDADD    = \
 	$(top_builddir)/src/libcommon-daemon-client.la \
 	$(top_builddir)/src/lib/liblldpctl.la \
@@ -41,6 +43,10 @@ dist_zshcompletion_DATA = completion/_lldpcli
 # Default configuration
 lldpdconfdir = $(sysconfdir)/lldpd.d
 dist_lldpdconf_DATA = README.conf
+
+# Organizational TLV config files
+orgtlvconfdir = $(sysconfdir)/lldpd.d/org-tlvs.conf.d
+dist_orgtlvconf_DATA = org-tlvs.conf.d/cisco.conf org-tlvs.conf.d/juniper.conf
 
 TEMPLATES  = lldpcli.8
 EXTRA_DIST = lldpcli.8.in

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -30,6 +30,8 @@
 
 #include "../log.h"
 #include "client.h"
+#include "org_tlv_handler.h"
+#include "org_tlv_conf.h"
 
 static void
 display_cap(struct writer *w, lldpctl_atom_t *chassis, u_int16_t bit,
@@ -286,51 +288,119 @@ display_chassis(struct writer *w, lldpctl_atom_t *chassis, int details)
 }
 
 static void
+display_custom_tlv_hex(struct writer *w, const uint8_t *oui, int subtype,
+    const uint8_t *oui_info, int len)
+{
+	size_t i, slen;
+	char buf[1600];
+
+	tag_start(w, "unknown-tlv", "TLV");
+	snprintf(buf, sizeof(buf), "%02X,%02X,%02X", oui[0], oui[1], oui[2]);
+	tag_attr(w, "oui", "OUI", buf);
+	snprintf(buf, sizeof(buf), "%d", subtype);
+	tag_attr(w, "subtype", "SubType", buf);
+	snprintf(buf, sizeof(buf), "%d", len);
+	tag_attr(w, "len", "Len", buf);
+	if (len > 0) {
+		for (slen = 0, i = 0; i < (size_t)len; ++i)
+			slen += snprintf(buf + slen,
+			    sizeof(buf) > slen ? sizeof(buf) - slen : 0, "%02X%s",
+			    oui_info[i], ((i < (size_t)len - 1) ? "," : ""));
+		tag_data(w, buf);
+	}
+	tag_end(w);
+}
+
+static void
 display_custom_tlvs(struct writer *w, lldpctl_atom_t *neighbor)
 {
 	lldpctl_atom_t *custom_list, *custom;
-	int have_custom_tlvs = 0;
-	size_t i, len, slen;
+	size_t len;
 	const uint8_t *oui, *oui_info;
-	char buf[1600]; /* should be enough for printing */
+
+	/* Track which vendor/unknown groups we've opened */
+	int have_unknown = 0;
+	uint8_t cur_group_oui[3] = { 0 };
+	int have_group = 0;
 
 	custom_list = lldpctl_atom_get(neighbor, lldpctl_k_custom_tlvs);
 	lldpctl_atom_foreach(custom_list, custom)
 	{
-		/* This tag gets added only once, if there are any custom TLVs */
-		if (!have_custom_tlvs) {
-			tag_start(w, "unknown-tlvs", "Unknown TLVs");
-			have_custom_tlvs++;
-		}
 		len = 0;
 		oui = lldpctl_atom_get_buffer(custom, lldpctl_k_custom_tlv_oui, &len);
 		len = 0;
 		oui_info = lldpctl_atom_get_buffer(custom,
 		    lldpctl_k_custom_tlv_oui_info_string, &len);
 		if (!oui) continue;
-		tag_start(w, "unknown-tlv", "TLV");
+		int subtype =
+		    (int)lldpctl_atom_get_int(custom, lldpctl_k_custom_tlv_oui_subtype);
+		int datalen = (int)len;
 
-		/* Add OUI as attribute */
-		snprintf(buf, sizeof(buf), "%02X,%02X,%02X", oui[0], oui[1], oui[2]);
-		tag_attr(w, "oui", "OUI", buf);
-		snprintf(buf, sizeof(buf), "%d",
-		    (int)lldpctl_atom_get_int(custom,
-			lldpctl_k_custom_tlv_oui_subtype));
-		tag_attr(w, "subtype", "SubType", buf);
-		snprintf(buf, sizeof(buf), "%d", (int)len);
-		tag_attr(w, "len", "Len", buf);
-		if (len > 0) {
-			for (slen = 0, i = 0; i < len; ++i)
-				slen += snprintf(buf + slen,
-				    sizeof(buf) > slen ? sizeof(buf) - slen : 0,
-				    "%02X%s", oui_info[i], ((i < len - 1) ? "," : ""));
-			tag_data(w, buf);
+		/* 1. Try code handler first */
+		struct org_tlv_handler *handler = org_tlv_handler_find(oui);
+		if (handler && handler->display(w, subtype, oui_info, datalen))
+			continue; /* handled by code */
+
+		/* 2. Try config definition */
+		struct org_tlv_def *def = org_tlv_conf_find(oui, subtype);
+		if (def) {
+			/* Open vendor group if needed */
+			const char *vendor_name = NULL;
+			if (handler)
+				vendor_name = handler->vendor_name;
+			else {
+				struct org_tlv_vendor *v = org_tlv_vendor_find(oui);
+				if (v) vendor_name = v->vendor_name;
+			}
+			if (vendor_name) {
+				if (!have_group ||
+				    memcmp(cur_group_oui, oui, 3) != 0) {
+					if (have_group) tag_end(w);
+					char tag[64];
+					snprintf(tag, sizeof(tag), "%s-tlvs",
+					    vendor_name);
+					/* Lowercase the tag */
+					for (char *p = tag; *p; p++)
+						*p = tolower((unsigned char)*p);
+					char descr[64];
+					snprintf(descr, sizeof(descr),
+					    "%s TLVs", vendor_name);
+					tag_start(w, tag, descr);
+					memcpy(cur_group_oui, oui, 3);
+					have_group = 1;
+				}
+			} else {
+				/* No vendor name — use unknown group */
+				if (have_group) {
+					tag_end(w);
+					have_group = 0;
+				}
+				if (!have_unknown) {
+					tag_start(w, "unknown-tlvs",
+					    "Unknown TLVs");
+					have_unknown = 1;
+				}
+			}
+			display_org_tlv_from_def(w, def, oui_info, datalen);
+			continue; /* handled by config */
 		}
-		tag_end(w);
+
+		/* 3. Fall back to hex (existing behavior) */
+		/* Close vendor group if we switched OUI */
+		if (have_group && memcmp(cur_group_oui, oui, 3) != 0) {
+			tag_end(w);
+			have_group = 0;
+		}
+		if (!have_unknown && !have_group) {
+			tag_start(w, "unknown-tlvs", "Unknown TLVs");
+			have_unknown = 1;
+		}
+		display_custom_tlv_hex(w, oui, subtype, oui_info, datalen);
 	}
 	lldpctl_atom_dec_ref(custom_list);
 
-	if (have_custom_tlvs) tag_end(w);
+	if (have_group) tag_end(w);
+	if (have_unknown) tag_end(w);
 }
 
 static void

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -356,6 +356,10 @@ display_custom_tlvs(struct writer *w, lldpctl_atom_t *neighbor)
 				if (!have_group ||
 				    memcmp(cur_group_oui, oui, 3) != 0) {
 					if (have_group) tag_end(w);
+					if (have_unknown) {
+						tag_end(w);
+						have_unknown = 0;
+					}
 					char tag[64];
 					snprintf(tag, sizeof(tag), "%s-tlvs",
 					    vendor_name);

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -1207,11 +1207,88 @@ command is issued.
 .Ed
 
 .Ed
+.Sh ORGANIZATIONAL TLV DISPLAY
+When
+.Nm
+displays neighbor information, organizational TLVs (Type 127) from
+vendors whose OUI is not natively handled (such as IEEE 802.1,
+802.3, LLDP-MED or DCBX) are normally shown as raw hex under
+.Dq Unknown TLVs .
+.Pp
+.Nm
+can interpret these TLVs using INI-style configuration files
+placed in
+.Pa @sysconfdir@/lldpd.d/org-tlvs.conf.d/ .
+Each file defines a vendor OUI and how to decode specific subtypes.
+.Pp
+A configuration file uses sections identified by OUI (and optionally
+subtype) in brackets.
+A section with only an OUI defines the vendor name.
+A section with OUI and subtype defines how to decode that TLV:
+.Bd -literal -offset indent
+[00:90:69]
+vendor = Juniper
+
+[00:90:69:1]
+name = Serial Number
+fields = string
+.Ed
+.Pp
+The
+.Ic fields
+value is a comma-separated list of field specifications.
+Each field is a type optionally followed by a colon and a label
+(e.g.\&
+.Ic uint8:status, uint32:port_id ) .
+When only a single unnamed field is defined, the TLV value is
+displayed directly with the TLV name as label.
+.Pp
+Supported field types:
+.Bl -tag -width "uint16" -compact -offset indent
+.It Sy uint8
+1-byte unsigned integer, displayed as decimal.
+.It Sy uint16
+2-byte unsigned integer (network byte order), displayed as decimal.
+.It Sy uint32
+4-byte unsigned integer (network byte order), displayed as decimal.
+.It Sy string
+Remaining bytes displayed as ASCII text.
+.It Sy ipv4
+4 bytes displayed as dotted-quad IPv4 address.
+.It Sy mac
+6 bytes displayed as colon-separated MAC address.
+.It Sy hex
+Remaining bytes displayed as hex dump.
+.El
+.Pp
+If the payload is longer than what the field definitions cover,
+remaining bytes are shown as hex.
+If shorter, parsing stops gracefully.
+.Pp
+Additionally, compiled code handlers can be registered for OUIs
+that require complex parsing (e.g.\& variable-length lists or
+conditional structures).
+Code handlers are checked first; if they do not handle a given
+subtype, the config file definition is tried, and finally the raw
+hex fallback is used.
+.Pp
+Configuration files are read at
+.Nm
+startup.
+Adding or modifying files requires restarting
+.Nm .
+The files shipped by default include definitions for Cisco ACI and
+Juniper TLVs.
 .Sh FILES
 .Bl -tag -width "@LLDPD_CTL_SOCKET@XX" -compact
 .It @LLDPD_CTL_SOCKET@
 Unix-domain socket used for communication with
 .Xr lldpd 8 .
+.It Pa @sysconfdir@/lldpd.d/org-tlvs.conf.d/
+Directory containing INI-style configuration files for
+organizational TLV display.
+Files must be suffixed with
+.Li .conf .
 .El
 .Sh SEE ALSO
 .Xr lldpd 8

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -1216,16 +1216,31 @@ vendors whose OUI is not natively handled (such as IEEE 802.1,
 .Dq Unknown TLVs .
 .Pp
 .Nm
-can interpret these TLVs using INI-style configuration files
-placed in
+can decode these TLVs using INI-style configuration files read from
 .Pa @sysconfdir@/lldpd.d/org-tlvs.conf.d/ .
-Each file defines a vendor OUI and how to decode specific subtypes.
+Only files whose name ends in
+.Li .conf
+are read, in alphabetical order, and only once when
+.Nm
+starts: adding or changing a file requires restarting
+.Nm .
+The files shipped by default describe Cisco ACI and Juniper TLVs.
+.Ss File syntax
+A file is a sequence of sections, each introduced by a header
+between square brackets.
+Empty lines are ignored, as is any line whose first non-blank
+character is
+.Li #
+or
+.Li \&; .
+Space around keys and values is stripped.
+A line is read 1023 characters at a time, so anything past that
+length is parsed as if it started a new line.
 .Pp
-A configuration file uses sections identified by OUI (and optionally
-subtype) in brackets.
-A section with only an OUI defines the vendor name.
-A section with OUI and subtype defines how to decode that TLV:
+A header made of three octets declares a vendor; a header made of
+three octets and a subtype describes one TLV:
 .Bd -literal -offset indent
+# Juniper organizational TLVs
 [00:90:69]
 vendor = Juniper
 
@@ -1234,51 +1249,116 @@ name = Serial Number
 fields = string
 .Ed
 .Pp
-The
+The three octets of the OUI are written in hexadecimal, but
+.Sy the subtype is read as a decimal number .
+Cisco ACI subtype 203 is therefore written
+.Li [00:01:42:203] ,
+not
+.Li [00:01:42:cb] .
+Beware that the latter is not rejected: the fourth component is
+simply not recognised as a subtype, the header is taken for a
+vendor declaration, and the
+.Ic name
+and
 .Ic fields
-value is a comma-separated list of field specifications.
-Each field is a type optionally followed by a colon and a label
-(e.g.\&
-.Ic uint8:status, uint32:port_id ) .
-When only a single unnamed field is defined, the TLV value is
-displayed directly with the TLV name as label.
-.Pp
-Supported field types:
-.Bl -tag -width "uint16" -compact -offset indent
-.It Sy uint8
-1-byte unsigned integer, displayed as decimal.
-.It Sy uint16
-2-byte unsigned integer (network byte order), displayed as decimal.
-.It Sy uint32
-4-byte unsigned integer (network byte order), displayed as decimal.
-.It Sy string
-Remaining bytes displayed as ASCII text.
-.It Sy ipv4
-4 bytes displayed as dotted-quad IPv4 address.
-.It Sy mac
-6 bytes displayed as colon-separated MAC address.
-.It Sy hex
-Remaining bytes displayed as hex dump.
+keys that follow are discarded without warning.
+A header holding less than three octets is reported and ignored.
+.Ss Vendor sections
+A vendor section holds a single key,
+.Ic vendor .
+Its value names the group under which the TLVs of that OUI are
+displayed.
+TLVs whose OUI has no vendor section are still decoded, but appear
+under
+.Dq Unknown TLVs .
+.Ss TLV sections
+A TLV section accepts the following keys:
+.Bl -tag -width "fields" -offset indent
+.It Ic name
+Label given to the TLV in the output.
+This key is required: a section without it is discarded, and the
+TLV falls back to the raw hex display.
+.It Ic fields
+Description of the payload, as a comma-separated list.
+When absent, the whole payload is displayed as
+.Dq Extra bytes .
 .El
 .Pp
-If the payload is longer than what the field definitions cover,
-remaining bytes are shown as hex.
-If shorter, parsing stops gracefully.
+Each entry of
+.Ic fields
+is a type, optionally followed by a colon and a label, as in
+.Li uint8:status, uint32:port_id .
+A list holding a single entry with no label is rendered as one
+value under the name of the TLV.
+Any other list is rendered as a group, each value appearing under
+its own label, or under the name of the TLV when the label is
+omitted.
+The two renderings do not treat an unexpected payload alike, as
+described below.
+An entry whose type is not known is reported and skipped, the
+remaining entries being kept.
 .Pp
-Additionally, compiled code handlers can be registered for OUIs
-that require complex parsing (e.g.\& variable-length lists or
-conditional structures).
-Code handlers are checked first; if they do not handle a given
-subtype, the config file definition is tried, and finally the raw
-hex fallback is used.
+The available types are:
+.Bl -tag -width "uint16" -compact -offset indent
+.It Sy uint8
+One byte, displayed as a decimal number.
+.It Sy uint16
+Two bytes, most significant first, displayed as a decimal number.
+.It Sy uint32
+Four bytes, most significant first, displayed as a decimal number.
+.It Sy ipv4
+Four bytes, displayed as a dotted quad.
+.It Sy mac
+Six bytes, displayed as lowercase hexadecimal separated by colons.
+.It Sy string
+All the remaining bytes, displayed as text.
+.It Sy hex
+All the remaining bytes, displayed as uppercase hexadecimal
+separated by commas.
+.El
 .Pp
-Configuration files are read at
-.Nm
-startup.
-Adding or modifying files requires restarting
+Because
+.Sy string
+and
+.Sy hex
+consume everything that is left, they only make sense as the last
+entry: any entry placed after them receives nothing.
+A long value may be truncated, around 255 characters.
+.Pp
+A payload rarely matches its description exactly, and the outcome
+depends on which of the two renderings applies.
+.Pp
+For a list of several entries, or a single labelled one, the bytes
+left over once every entry has been served are displayed as
+.Dq Extra bytes ,
+in uppercase hexadecimal separated by commas.
+Should the payload run out first, the entry that does not fit is
+dropped together with those that follow it, leaving only the values
+already collected.
+.Pp
+For a single entry with no label, no such care is taken: the bytes
+beyond the one value are
+.Sy discarded silently ,
+and a payload too short for that value yields
+.Sy nothing at all ,
+the TLV vanishing from the output instead of falling back to its
+hex form.
+A definition written this way is therefore only appropriate when
+the payload is known to hold exactly that one value; giving the
+entry a label is enough to obtain the careful behaviour.
+.Ss Precedence
+When several files describe the same OUI and subtype, the
+definition read last prevails.
+When several of them declare a vendor for the same OUI, the name
+read first prevails.
+.Ss Code handlers
+TLVs needing more than a flat list of fields, such as
+variable-length lists or structures whose shape depends on their
+content, can be handled by code compiled into
 .Nm .
-The files shipped by default include definitions for Cisco ACI and
-Juniper TLVs.
+A code handler is consulted first; when it does not handle the
+subtype at hand, the configuration files are used, and the raw hex
+display serves as a last resort.
 .Sh FILES
 .Bl -tag -width "@LLDPD_CTL_SOCKET@XX" -compact
 .It @LLDPD_CTL_SOCKET@

--- a/src/client/lldpcli.c
+++ b/src/client/lldpcli.c
@@ -32,6 +32,8 @@
 #include <sys/queue.h>
 
 #include "client.h"
+#include "org_tlv_handler.h"
+#include "org_tlv_conf.h"
 
 #ifdef HAVE___PROGNAME
 extern const char *__progname;
@@ -518,6 +520,10 @@ main(int argc, char *argv[])
 	/* Register commands */
 	root = register_commands();
 
+	/* Initialize organizational TLV handlers and load config */
+	org_tlv_handler_init();
+	org_tlv_conf_load(SYSCONFDIR "/lldpd.d/org-tlvs.conf.d");
+
 	/* Make a connection */
 	log_debug("lldpctl", "connect to lldpd");
 	conn = lldpctl_new_name(ctlname, NULL, NULL, NULL);
@@ -628,5 +634,6 @@ end:
 	}
 	if (conn) lldpctl_release(conn);
 	if (root) commands_free(root);
+	org_tlv_conf_free();
 	return rc;
 }

--- a/src/client/org-tlvs.conf.d/cisco.conf
+++ b/src/client/org-tlvs.conf.d/cisco.conf
@@ -1,0 +1,45 @@
+# Cisco ACI organizational TLV definitions
+# OUI 00:01:42
+
+[00:01:42]
+vendor = Cisco
+
+[00:01:42:203]
+name = Node ID
+fields = uint32
+
+[00:01:42:205]
+name = Pod ID
+fields = uint16
+
+[00:01:42:206]
+name = Fabric Name
+fields = string
+
+[00:01:42:208]
+name = TEP Address
+fields = ipv4
+
+[00:01:42:209]
+name = Role
+fields = uint8
+
+[00:01:42:210]
+name = Software Version
+fields = string
+
+[00:01:42:212]
+name = Serial Number
+fields = string
+
+[00:01:42:214]
+name = Model
+fields = string
+
+[00:01:42:215]
+name = Node Name
+fields = string
+
+[00:01:42:220]
+name = Fabric Type
+fields = uint8

--- a/src/client/org-tlvs.conf.d/juniper.conf
+++ b/src/client/org-tlvs.conf.d/juniper.conf
@@ -1,0 +1,9 @@
+# Juniper organizational TLV definitions
+# OUI 00:90:69
+
+[00:90:69]
+vendor = Juniper
+
+[00:90:69:1]
+name = Serial Number
+fields = string

--- a/src/client/org_tlv_conf.c
+++ b/src/client/org_tlv_conf.c
@@ -1,0 +1,544 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2026 Ciro Iriarte <ciro.iriarte+software@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <arpa/inet.h>
+
+#include "../log.h"
+#include "org_tlv_conf.h"
+
+static struct org_tlv_def *def_list = NULL;
+static struct org_tlv_vendor *vendor_list = NULL;
+
+struct org_tlv_def *
+org_tlv_conf_find(const uint8_t *oui, uint8_t subtype)
+{
+	struct org_tlv_def *d;
+	for (d = def_list; d; d = d->next) {
+		if (memcmp(d->oui, oui, 3) == 0 && d->subtype == subtype)
+			return d;
+	}
+	return NULL;
+}
+
+struct org_tlv_vendor *
+org_tlv_vendor_find(const uint8_t *oui)
+{
+	struct org_tlv_vendor *v;
+	for (v = vendor_list; v; v = v->next) {
+		if (memcmp(v->oui, oui, 3) == 0) return v;
+	}
+	return NULL;
+}
+
+static char *
+strip(char *s)
+{
+	while (*s && isspace((unsigned char)*s))
+		s++;
+	char *end = s + strlen(s) - 1;
+	while (end > s && isspace((unsigned char)*end))
+		*end-- = '\0';
+	return s;
+}
+
+/* Parse a field type string into enum */
+static int
+parse_field_type(const char *s, enum org_tlv_field_type *type)
+{
+	if (strcmp(s, "uint8") == 0) {
+		*type = ORG_TLV_UINT8;
+	} else if (strcmp(s, "uint16") == 0) {
+		*type = ORG_TLV_UINT16;
+	} else if (strcmp(s, "uint32") == 0) {
+		*type = ORG_TLV_UINT32;
+	} else if (strcmp(s, "string") == 0) {
+		*type = ORG_TLV_STRING;
+	} else if (strcmp(s, "ipv4") == 0) {
+		*type = ORG_TLV_IPV4;
+	} else if (strcmp(s, "mac") == 0) {
+		*type = ORG_TLV_MAC;
+	} else if (strcmp(s, "hex") == 0) {
+		*type = ORG_TLV_HEX;
+	} else {
+		return -1;
+	}
+	return 0;
+}
+
+/* Parse "fields" value: e.g. "uint8:status, uint32:port_id" or just "string" */
+static struct org_tlv_field *
+parse_fields(const char *value)
+{
+	struct org_tlv_field *head = NULL, *tail = NULL;
+	char *copy = strdup(value);
+	if (!copy) return NULL;
+
+	char *saveptr = NULL;
+	char *token = strtok_r(copy, ",", &saveptr);
+	while (token) {
+		char *s = strip(token);
+		if (*s == '\0') {
+			token = strtok_r(NULL, ",", &saveptr);
+			continue;
+		}
+
+		struct org_tlv_field *f = calloc(1, sizeof(*f));
+		if (!f) break;
+
+		/* Check for type:name format */
+		char *colon = strchr(s, ':');
+		if (colon) {
+			*colon = '\0';
+			char *type_str = strip(s);
+			char *name_str = strip(colon + 1);
+			if (parse_field_type(type_str, &f->type) < 0) {
+				log_warnx("lldpctl",
+				    "org-tlv config: unknown field type '%s'",
+				    type_str);
+				free(f);
+				token = strtok_r(NULL, ",", &saveptr);
+				continue;
+			}
+			f->name = strdup(name_str);
+		} else {
+			if (parse_field_type(s, &f->type) < 0) {
+				log_warnx("lldpctl",
+				    "org-tlv config: unknown field type '%s'", s);
+				free(f);
+				token = strtok_r(NULL, ",", &saveptr);
+				continue;
+			}
+			f->name = NULL;
+		}
+
+		if (tail) {
+			tail->next = f;
+		} else {
+			head = f;
+		}
+		tail = f;
+
+		token = strtok_r(NULL, ",", &saveptr);
+	}
+	free(copy);
+	return head;
+}
+
+/* Parse section header: "AA:BB:CC" (vendor) or "AA:BB:CC:subtype" (TLV def) */
+static int
+parse_section(const char *section, uint8_t *oui, int *subtype)
+{
+	unsigned int a, b, c, s;
+	int n = sscanf(section, "%x:%x:%x:%u", &a, &b, &c, &s);
+	if (n < 3) return -1;
+	if (a > 255 || b > 255 || c > 255) return -1;
+	oui[0] = (uint8_t)a;
+	oui[1] = (uint8_t)b;
+	oui[2] = (uint8_t)c;
+	if (n == 4) {
+		if (s > 255) return -1;
+		*subtype = (int)s;
+	} else {
+		*subtype = -1; /* vendor-only section */
+	}
+	return 0;
+}
+
+static void
+org_tlv_conf_load_file(const char *path)
+{
+	FILE *fp = fopen(path, "r");
+	if (!fp) {
+		log_warnx("lldpctl", "org-tlv config: cannot open %s", path);
+		return;
+	}
+
+	log_debug("lldpctl", "org-tlv config: loading %s", path);
+
+	char line[1024];
+	uint8_t cur_oui[3] = { 0 };
+	int cur_subtype = -1;
+	int have_section = 0;
+
+	/* Temporary storage for current section's key-value pairs */
+	char *cur_name = NULL;
+	char *cur_vendor = NULL;
+	char *cur_fields = NULL;
+
+	while (fgets(line, sizeof(line), fp)) {
+		char *s = strip(line);
+		if (*s == '\0' || *s == '#' || *s == ';') continue;
+
+		/* Section header */
+		if (*s == '[') {
+			/* Save previous section first */
+			if (have_section) {
+				if (cur_subtype < 0 && cur_vendor) {
+					/* Vendor definition */
+					if (!org_tlv_vendor_find(cur_oui)) {
+						struct org_tlv_vendor *v =
+						    calloc(1, sizeof(*v));
+						if (v) {
+							memcpy(v->oui, cur_oui,
+							    3);
+							v->vendor_name =
+							    cur_vendor;
+							cur_vendor = NULL;
+							v->next = vendor_list;
+							vendor_list = v;
+						}
+					}
+				} else if (cur_subtype >= 0 && cur_name) {
+					/* TLV definition */
+					struct org_tlv_def *d =
+					    calloc(1, sizeof(*d));
+					if (d) {
+						memcpy(d->oui, cur_oui, 3);
+						d->subtype =
+						    (uint8_t)cur_subtype;
+						d->name = cur_name;
+						cur_name = NULL;
+						d->fields = cur_fields ?
+						    parse_fields(cur_fields) :
+						    NULL;
+						d->next = def_list;
+						def_list = d;
+					}
+				}
+			}
+			free(cur_name);
+			free(cur_vendor);
+			free(cur_fields);
+			cur_name = NULL;
+			cur_vendor = NULL;
+			cur_fields = NULL;
+
+			char *end = strchr(s, ']');
+			if (!end) {
+				log_warnx("lldpctl",
+				    "org-tlv config: malformed section in %s",
+				    path);
+				have_section = 0;
+				continue;
+			}
+			*end = '\0';
+			if (parse_section(s + 1, cur_oui, &cur_subtype) < 0) {
+				log_warnx("lldpctl",
+				    "org-tlv config: invalid section '%s' in %s",
+				    s + 1, path);
+				have_section = 0;
+				continue;
+			}
+			have_section = 1;
+			continue;
+		}
+
+		if (!have_section) continue;
+
+		/* Key = value */
+		char *eq = strchr(s, '=');
+		if (!eq) continue;
+		*eq = '\0';
+		char *key = strip(s);
+		char *val = strip(eq + 1);
+
+		if (strcmp(key, "vendor") == 0) {
+			free(cur_vendor);
+			cur_vendor = strdup(val);
+		} else if (strcmp(key, "name") == 0) {
+			free(cur_name);
+			cur_name = strdup(val);
+		} else if (strcmp(key, "fields") == 0) {
+			free(cur_fields);
+			cur_fields = strdup(val);
+		}
+	}
+
+	/* Save last section */
+	if (have_section) {
+		if (cur_subtype < 0 && cur_vendor) {
+			if (!org_tlv_vendor_find(cur_oui)) {
+				struct org_tlv_vendor *v = calloc(1, sizeof(*v));
+				if (v) {
+					memcpy(v->oui, cur_oui, 3);
+					v->vendor_name = cur_vendor;
+					cur_vendor = NULL;
+					v->next = vendor_list;
+					vendor_list = v;
+				}
+			}
+		} else if (cur_subtype >= 0 && cur_name) {
+			struct org_tlv_def *d = calloc(1, sizeof(*d));
+			if (d) {
+				memcpy(d->oui, cur_oui, 3);
+				d->subtype = (uint8_t)cur_subtype;
+				d->name = cur_name;
+				cur_name = NULL;
+				d->fields = cur_fields ? parse_fields(cur_fields) :
+							 NULL;
+				d->next = def_list;
+				def_list = d;
+			}
+		}
+	}
+	free(cur_name);
+	free(cur_vendor);
+	free(cur_fields);
+	fclose(fp);
+}
+
+static int
+conf_filter(const struct dirent *dir)
+{
+	size_t len = strlen(dir->d_name);
+	if (len < 5) return 0;
+	if (strcmp(dir->d_name + len - 5, ".conf")) return 0;
+	return 1;
+}
+
+void
+org_tlv_conf_load(const char *dir)
+{
+	struct stat statbuf;
+	if (stat(dir, &statbuf) == -1 || !S_ISDIR(statbuf.st_mode)) {
+		log_debug("lldpctl", "org-tlv config: directory %s not found", dir);
+		return;
+	}
+
+	struct dirent **namelist = NULL;
+	int n = scandir(dir, &namelist, conf_filter, alphasort);
+	if (n < 0) {
+		log_debug("lldpctl",
+		    "org-tlv config: unable to read directory %s", dir);
+		return;
+	}
+	for (int i = 0; i < n; i++) {
+		char *fullname;
+		if (asprintf(&fullname, "%s/%s", dir, namelist[i]->d_name) != -1) {
+			org_tlv_conf_load_file(fullname);
+			free(fullname);
+		}
+		free(namelist[i]);
+	}
+	free(namelist);
+}
+
+void
+display_org_tlv_from_def(struct writer *w, struct org_tlv_def *def,
+    const uint8_t *data, int datalen)
+{
+	int pos = 0;
+
+	/* If there's only one field with no name, use simple tag_datatag */
+	if (def->fields && !def->fields->next && !def->fields->name) {
+		struct org_tlv_field *f = def->fields;
+		char buf[256];
+		switch (f->type) {
+		case ORG_TLV_UINT8:
+			if (pos + 1 <= datalen) {
+				snprintf(buf, sizeof(buf), "%u", data[pos]);
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		case ORG_TLV_UINT16:
+			if (pos + 2 <= datalen) {
+				uint16_t v =
+				    ((uint16_t)data[pos] << 8) | data[pos + 1];
+				snprintf(buf, sizeof(buf), "%u", v);
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		case ORG_TLV_UINT32:
+			if (pos + 4 <= datalen) {
+				uint32_t v =
+				    ((uint32_t)data[pos] << 24) |
+				    ((uint32_t)data[pos + 1] << 16) |
+				    ((uint32_t)data[pos + 2] << 8) |
+				    data[pos + 3];
+				snprintf(buf, sizeof(buf), "%u", v);
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		case ORG_TLV_STRING: {
+			int slen = datalen - pos;
+			if (slen > (int)(sizeof(buf) - 1))
+				slen = sizeof(buf) - 1;
+			if (slen > 0) {
+				memcpy(buf, data + pos, slen);
+				buf[slen] = '\0';
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		}
+		case ORG_TLV_IPV4:
+			if (pos + 4 <= datalen) {
+				snprintf(buf, sizeof(buf), "%u.%u.%u.%u",
+				    data[pos], data[pos + 1], data[pos + 2],
+				    data[pos + 3]);
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		case ORG_TLV_MAC:
+			if (pos + 6 <= datalen) {
+				snprintf(buf, sizeof(buf),
+				    "%02x:%02x:%02x:%02x:%02x:%02x", data[pos],
+				    data[pos + 1], data[pos + 2], data[pos + 3],
+				    data[pos + 4], data[pos + 5]);
+				tag_datatag(w, "value", def->name, buf);
+			}
+			return;
+		case ORG_TLV_HEX: {
+			size_t slen = 0;
+			for (int i = pos; i < datalen && slen < sizeof(buf) - 3;
+			     i++)
+				slen += snprintf(buf + slen, sizeof(buf) - slen,
+				    "%s%02X", (i > pos) ? "," : "", data[i]);
+			tag_datatag(w, "value", def->name, buf);
+			return;
+		}
+		}
+		return;
+	}
+
+	/* Multiple fields or named fields: wrap in a container tag */
+	tag_start(w, "org-tlv", def->name);
+	struct org_tlv_field *f;
+	for (f = def->fields; f && pos < datalen; f = f->next) {
+		char buf[256];
+		const char *label = f->name ? f->name : def->name;
+		const char *tag = f->name ? f->name : "value";
+
+		switch (f->type) {
+		case ORG_TLV_UINT8:
+			if (pos + 1 > datalen) goto done;
+			snprintf(buf, sizeof(buf), "%u", data[pos]);
+			tag_datatag(w, tag, label, buf);
+			pos += 1;
+			break;
+		case ORG_TLV_UINT16:
+			if (pos + 2 > datalen) goto done;
+			{
+				uint16_t v = ((uint16_t)data[pos] << 8) |
+				    data[pos + 1];
+				snprintf(buf, sizeof(buf), "%u", v);
+				tag_datatag(w, tag, label, buf);
+			}
+			pos += 2;
+			break;
+		case ORG_TLV_UINT32:
+			if (pos + 4 > datalen) goto done;
+			{
+				uint32_t v =
+				    ((uint32_t)data[pos] << 24) |
+				    ((uint32_t)data[pos + 1] << 16) |
+				    ((uint32_t)data[pos + 2] << 8) |
+				    data[pos + 3];
+				snprintf(buf, sizeof(buf), "%u", v);
+				tag_datatag(w, tag, label, buf);
+			}
+			pos += 4;
+			break;
+		case ORG_TLV_STRING: {
+			int slen = datalen - pos;
+			if (slen > (int)(sizeof(buf) - 1))
+				slen = sizeof(buf) - 1;
+			if (slen > 0) {
+				memcpy(buf, data + pos, slen);
+				buf[slen] = '\0';
+				tag_datatag(w, tag, label, buf);
+			}
+			pos = datalen;
+			break;
+		}
+		case ORG_TLV_IPV4:
+			if (pos + 4 > datalen) goto done;
+			snprintf(buf, sizeof(buf), "%u.%u.%u.%u", data[pos],
+			    data[pos + 1], data[pos + 2], data[pos + 3]);
+			tag_datatag(w, tag, label, buf);
+			pos += 4;
+			break;
+		case ORG_TLV_MAC:
+			if (pos + 6 > datalen) goto done;
+			snprintf(buf, sizeof(buf),
+			    "%02x:%02x:%02x:%02x:%02x:%02x", data[pos],
+			    data[pos + 1], data[pos + 2], data[pos + 3],
+			    data[pos + 4], data[pos + 5]);
+			tag_datatag(w, tag, label, buf);
+			pos += 6;
+			break;
+		case ORG_TLV_HEX: {
+			size_t slen = 0;
+			for (int i = pos; i < datalen && slen < sizeof(buf) - 3;
+			     i++)
+				slen += snprintf(buf + slen, sizeof(buf) - slen,
+				    "%s%02X", (i > pos) ? "," : "", data[i]);
+			tag_datatag(w, tag, label, buf);
+			pos = datalen;
+			break;
+		}
+		}
+	}
+
+	/* Remaining bytes as hex */
+	if (pos < datalen) {
+		char buf[1600];
+		size_t slen = 0;
+		for (int i = pos; i < datalen && slen < sizeof(buf) - 3; i++)
+			slen += snprintf(buf + slen, sizeof(buf) - slen, "%s%02X",
+			    (i > pos) ? "," : "", data[i]);
+		tag_datatag(w, "extra", "Extra bytes", buf);
+	}
+
+done:
+	tag_end(w);
+}
+
+static void
+free_fields(struct org_tlv_field *f)
+{
+	while (f) {
+		struct org_tlv_field *next = f->next;
+		free(f->name);
+		free(f);
+		f = next;
+	}
+}
+
+void
+org_tlv_conf_free(void)
+{
+	while (def_list) {
+		struct org_tlv_def *next = def_list->next;
+		free(def_list->name);
+		free_fields(def_list->fields);
+		free(def_list);
+		def_list = next;
+	}
+	while (vendor_list) {
+		struct org_tlv_vendor *next = vendor_list->next;
+		free(vendor_list->vendor_name);
+		free(vendor_list);
+		vendor_list = next;
+	}
+}

--- a/src/client/org_tlv_conf.h
+++ b/src/client/org_tlv_conf.h
@@ -1,0 +1,74 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2026 Ciro Iriarte <ciro.iriarte+software@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _ORG_TLV_CONF_H
+#define _ORG_TLV_CONF_H
+
+#include <stdint.h>
+#include "writer.h"
+
+/* Field type enum */
+enum org_tlv_field_type {
+	ORG_TLV_UINT8,
+	ORG_TLV_UINT16,
+	ORG_TLV_UINT32,
+	ORG_TLV_STRING,
+	ORG_TLV_IPV4,
+	ORG_TLV_MAC,
+	ORG_TLV_HEX,
+};
+
+/* Single field within a TLV definition */
+struct org_tlv_field {
+	char *name;
+	enum org_tlv_field_type type;
+	struct org_tlv_field *next;
+};
+
+/* Definition for one OUI+subtype */
+struct org_tlv_def {
+	uint8_t oui[3];
+	uint8_t subtype;
+	char *name;
+	struct org_tlv_field *fields;
+	struct org_tlv_def *next;
+};
+
+/* Vendor definition (one per OUI) */
+struct org_tlv_vendor {
+	uint8_t oui[3];
+	char *vendor_name;
+	struct org_tlv_vendor *next;
+};
+
+/* Load all .conf files from directory */
+void org_tlv_conf_load(const char *dir);
+
+/* Lookup a TLV definition by OUI + subtype */
+struct org_tlv_def *org_tlv_conf_find(const uint8_t *oui, uint8_t subtype);
+
+/* Lookup a vendor name by OUI */
+struct org_tlv_vendor *org_tlv_vendor_find(const uint8_t *oui);
+
+/* Display a TLV using a config definition */
+void display_org_tlv_from_def(struct writer *w, struct org_tlv_def *def,
+    const uint8_t *data, int datalen);
+
+/* Free all loaded config data */
+void org_tlv_conf_free(void);
+
+#endif /* _ORG_TLV_CONF_H */

--- a/src/client/org_tlv_handler.c
+++ b/src/client/org_tlv_handler.c
@@ -1,0 +1,48 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2026 Ciro Iriarte <ciro.iriarte+software@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <string.h>
+#include "org_tlv_handler.h"
+
+static struct org_tlv_handler *handler_list = NULL;
+
+void
+org_tlv_handler_register(struct org_tlv_handler *handler)
+{
+	handler->next = handler_list;
+	handler_list = handler;
+}
+
+struct org_tlv_handler *
+org_tlv_handler_find(const uint8_t *oui)
+{
+	struct org_tlv_handler *h;
+	for (h = handler_list; h; h = h->next) {
+		if (memcmp(h->oui, oui, 3) == 0)
+			return h;
+	}
+	return NULL;
+}
+
+/* Initialize all registered handlers */
+void org_tlv_handler_init_cisco_handler(void);
+
+void
+org_tlv_handler_init(void)
+{
+	org_tlv_handler_init_cisco_handler();
+}

--- a/src/client/org_tlv_handler.h
+++ b/src/client/org_tlv_handler.h
@@ -1,0 +1,50 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2026 Ciro Iriarte <ciro.iriarte+software@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _ORG_TLV_HANDLER_H
+#define _ORG_TLV_HANDLER_H
+
+#include <stdint.h>
+#include "writer.h"
+
+/* Handler callback: interpret raw TLV bytes and produce display output.
+ * Return 1 if handled, 0 to fall through to config/hex. */
+typedef int (*org_tlv_display_fn)(struct writer *w, uint8_t subtype,
+    const uint8_t *data, int datalen);
+
+/* One handler per OUI (handles all subtypes for that vendor) */
+struct org_tlv_handler {
+	uint8_t oui[3];
+	const char *vendor_name;
+	org_tlv_display_fn display;
+	struct org_tlv_handler *next;
+};
+
+/* Registration and lookup */
+void org_tlv_handler_register(struct org_tlv_handler *handler);
+struct org_tlv_handler *org_tlv_handler_find(const uint8_t *oui);
+void org_tlv_handler_init(void);
+
+/* Registration macro — call from each handler file */
+#define ORG_TLV_HANDLER_REGISTER(NAME)      \
+  void org_tlv_handler_init_##NAME(void);   \
+  void org_tlv_handler_init_##NAME(void)    \
+  {                                         \
+    org_tlv_handler_register(&NAME);        \
+  }
+
+#endif /* _ORG_TLV_HANDLER_H */

--- a/src/client/org_tlv_handler_cisco.c
+++ b/src/client/org_tlv_handler_cisco.c
@@ -1,0 +1,66 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2026 Ciro Iriarte <ciro.iriarte+software@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <string.h>
+#include "org_tlv_handler.h"
+
+static int
+cisco_display(struct writer *w, uint8_t subtype, const uint8_t *data, int datalen)
+{
+	switch (subtype) {
+	case 207: {
+		/* ACI Policy Group UUIDs — list of 41-byte entries:
+		 *   1 byte tier, 4 bytes reserved, 36 bytes UUID (ASCII) */
+		const char *tier_names[] = {
+			[0] = "Unknown",
+			[1] = "Tenant",
+			[2] = "App Profile",
+			[3] = "EPG",
+			[4] = "Bridge Domain",
+			[5] = "VRF",
+		};
+		int ntiers = sizeof(tier_names) / sizeof(tier_names[0]);
+		tag_start(w, "aci-policy-groups", "ACI Policy Groups");
+		int pos = 0;
+		while (pos + 41 <= datalen) {
+			uint8_t tier = data[pos];
+			const char *uuid_ascii = (const char *)&data[pos + 5];
+			char uuid[37];
+			memcpy(uuid, uuid_ascii, 36);
+			uuid[36] = '\0';
+			const char *name =
+			    (tier < ntiers) ? tier_names[tier] : "Unknown";
+			tag_start(w, "policy-group", name);
+			tag_data(w, uuid);
+			tag_end(w);
+			pos += 41;
+		}
+		tag_end(w);
+		return 1; /* handled */
+	}
+	default:
+		return 0; /* not handled — fall through to config/hex */
+	}
+}
+
+static struct org_tlv_handler cisco_handler = {
+	.oui = { 0x00, 0x01, 0x42 },
+	.vendor_name = "Cisco",
+	.display = cisco_display,
+};
+
+ORG_TLV_HANDLER_REGISTER(cisco_handler);

--- a/tests/integration/test_org_tlv.py
+++ b/tests/integration/test_org_tlv.py
@@ -204,6 +204,25 @@ def test_org_tlv_no_definition_falls_back_to_hex(
 @pytest.mark.skipif(
     "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
 )
+def test_org_tlv_vendor_group_is_not_nested_in_unknown(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A vendor group opened after an unknown one is a sibling, not a child."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OTHER_OUI, 1, "41,42"), (OUI, 1, "43,44"))
+    with namespaces(1):
+        org_tlv_conf(
+            a=definition(OTHER_OUI, 1, "No vendor", "string"),
+            b=definition(OUI, 1, "With vendor", "string", vendor="Testvendor"),
+        )
+        out = neighbors(lldpcli)
+    assert out["unknown-tlvs.value"] == "AB"
+    assert out["testvendor-tlvs.value"] == "CD"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
 def test_org_tlv_single_field_ignores_trailing_bytes(
     lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
 ):

--- a/tests/integration/test_org_tlv.py
+++ b/tests/integration/test_org_tlv.py
@@ -47,6 +47,7 @@ def org_tlv_conf(request):
         for name, content in files.items():
             with open(os.path.join(orgdir, "{}.conf".format(name)), "w") as f:
                 f.write(content)
+        return orgdir
 
     return install
 
@@ -198,3 +199,175 @@ def test_org_tlv_no_definition_falls_back_to_hex(
     assert out["unknown-tlvs.unknown-tlv.oui"] == "00,11,22"
     assert out["unknown-tlvs.unknown-tlv.subtype"] == "9"
     assert out["unknown-tlvs.unknown-tlv"] == "45,45,45"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_single_field_ignores_trailing_bytes(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A single unlabelled field discards what follows the value."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "C0,A8,01,0A,DE,AD,BE,EF"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Address", "ipv4", vendor="Testvendor")
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.value"] == "192.168.1.10"
+    assert "testvendor-tlvs.extra" not in out
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_single_field_too_short_displays_nothing(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A single unlabelled field wider than the payload hides the TLV."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "01,02"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Number", "uint32", vendor="Testvendor")
+        )
+        out = neighbors(lldpcli)
+    assert not [k for k in out if "tlv" in k]
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_named_fields_report_extra_bytes(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """Bytes left over by labelled fields are displayed apart."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "07,DE,AD"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Alpha", "uint8:alpha", vendor="Testvendor")
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.alpha"] == "7"
+    assert out["testvendor-tlvs.org-tlv.extra"] == "DE,AD"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_named_fields_stop_on_short_payload(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A labelled field that does not fit is dropped along with the next ones."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "07,01"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(
+                OUI,
+                1,
+                "Alpha",
+                "uint8:alpha, uint32:beta, uint8:gamma",
+                vendor="Testvendor",
+            )
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.alpha"] == "7"
+    assert "testvendor-tlvs.org-tlv.beta" not in out
+    assert "testvendor-tlvs.org-tlv.gamma" not in out
+    assert "testvendor-tlvs.org-tlv.extra" not in out
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_without_fields_shows_whole_payload(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A definition with no fields displays the payload as extra bytes."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor="[{o}]\nvendor = Testvendor\n\n[{o}:1]\nname = Blob\n".format(
+                o=OUI
+            )
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.extra"] == "41,42"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_unknown_field_type_is_skipped(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """An unknown type is dropped and the other fields are still decoded."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "07"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(
+                OUI, 1, "Alpha", "bogus:nope, uint8:alpha", vendor="Testvendor"
+            )
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.alpha"] == "7"
+    assert "testvendor-tlvs.org-tlv.nope" not in out
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_definition_precedence(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """The last definition of a TLV wins, but the first vendor name does."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41"))
+    with namespaces(1):
+        org_tlv_conf(
+            a=definition(OUI, 1, "From a", "uint8:froma", vendor="Vendora"),
+            b=definition(OUI, 1, "From b", "uint8:fromb", vendor="Vendorb"),
+        )
+        out = neighbors(lldpcli)
+    assert out["vendora-tlvs.org-tlv.fromb"] == "65"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_ignores_files_without_conf_suffix(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """Only files suffixed with .conf are read."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42"))
+    with namespaces(1):
+        orgdir = org_tlv_conf()
+        with open(os.path.join(orgdir, "testvendor.txt"), "w") as f:
+            f.write(definition(OUI, 1, "Ignored", "string", vendor="Testvendor"))
+        out = neighbors(lldpcli)
+    assert out["unknown-tlvs.unknown-tlv"] == "41,42"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_definition_without_name_is_ignored(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """A definition lacking a name is discarded, leaving the hex display."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor="[{o}]\nvendor = Testvendor\n\n[{o}:1]\nfields = string\n".format(
+                o=OUI
+            )
+        )
+        out = neighbors(lldpcli)
+    assert out["unknown-tlvs.unknown-tlv"] == "41,42"

--- a/tests/integration/test_org_tlv.py
+++ b/tests/integration/test_org_tlv.py
@@ -33,14 +33,22 @@ def org_tlv_conf(request):
 
     lldpcli reads SYSCONFDIR/lldpd.d/org-tlvs.conf.d. A tmpfs is mounted over
     lldpd.d before anything is written, so the definition files stay in the
-    calling mount namespace. The lldpd.d directory itself is created on the
-    real filesystem when missing, like "make install" would, and is left
-    empty. This has to be called from inside the namespace running lldpcli.
+    calling mount namespace. Only the directories leading to it are real, and
+    they are removed once the test is over. This has to be called from inside
+    the namespace running lldpcli.
     """
     lldpd_d = os.path.join(request.config.lldpd.confdir, "lldpd.d")
+    created = []
 
     def install(**files):
-        os.makedirs(lldpd_d, exist_ok=True)
+        # Creating a directory is not confined to the mount namespace, unlike
+        # the tmpfs mounted over it, so remember what will have to be undone.
+        path = lldpd_d
+        while not os.path.isdir(path):
+            created.append(path)
+            path = os.path.dirname(path)
+        for path in reversed(created):
+            os.mkdir(path)
         mount_tmpfs(lldpd_d)
         orgdir = os.path.join(lldpd_d, "org-tlvs.conf.d")
         os.mkdir(orgdir)
@@ -49,7 +57,14 @@ def org_tlv_conf(request):
                 f.write(content)
         return orgdir
 
-    return install
+    yield install
+
+    # The tmpfs is gone with the namespace, leaving the directories empty.
+    for path in created:
+        try:
+            os.rmdir(path)
+        except OSError:
+            pass
 
 
 def emit(lldpd, lldpcli, *tlvs):
@@ -390,3 +405,26 @@ def test_org_tlv_definition_without_name_is_ignored(
         )
         out = neighbors(lldpcli)
     assert out["unknown-tlvs.unknown-tlv"] == "41,42"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_name_and_vendor_label_the_output(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """The name and the vendor are the labels of the plain text output."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42,43,31,32,33"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(
+                OUI, 1, "Serial Number", "string", vendor="Testvendor"
+            )
+        )
+        result = lldpcli("show", "neighbors", "details")
+    assert result.returncode == 0
+    out = result.stdout.decode("ascii")
+    assert "Testvendor TLVs" in out
+    labelled = [line for line in out.splitlines() if "Serial Number" in line]
+    assert labelled and "ABC123" in labelled[0]

--- a/tests/integration/test_org_tlv.py
+++ b/tests/integration/test_org_tlv.py
@@ -1,0 +1,200 @@
+import os
+import pytest
+import shlex
+import time
+
+from fixtures.namespaces import mount_tmpfs
+
+# OUIs reserved for the tests. They must not collide with the definitions
+# shipped in org-tlvs.conf.d, otherwise the expectations below would depend
+# on files we do not control here.
+OUI = "00:11:22"
+OTHER_OUI = "00:11:33"
+
+
+def definition(oui, subtype, name, fields, vendor=None):
+    """Build an org-tlv configuration section for a single subtype.
+
+    A vendor section is prepended when ``vendor`` is given. Sections can be
+    concatenated to describe several subtypes in one file.
+    """
+    return "{}\n[{}:{}]\nname = {}\nfields = {}\n".format(
+        vendor and "[{}]\nvendor = {}\n".format(oui, vendor) or "",
+        oui,
+        subtype,
+        name,
+        fields,
+    )
+
+
+@pytest.fixture
+def org_tlv_conf(request):
+    """Install org-tlv definitions where lldpcli looks for them.
+
+    lldpcli reads SYSCONFDIR/lldpd.d/org-tlvs.conf.d. A tmpfs is mounted over
+    lldpd.d before anything is written, so the definition files stay in the
+    calling mount namespace. The lldpd.d directory itself is created on the
+    real filesystem when missing, like "make install" would, and is left
+    empty. This has to be called from inside the namespace running lldpcli.
+    """
+    lldpd_d = os.path.join(request.config.lldpd.confdir, "lldpd.d")
+
+    def install(**files):
+        os.makedirs(lldpd_d, exist_ok=True)
+        mount_tmpfs(lldpd_d)
+        orgdir = os.path.join(lldpd_d, "org-tlvs.conf.d")
+        os.mkdir(orgdir)
+        for name, content in files.items():
+            with open(os.path.join(orgdir, "{}.conf".format(name)), "w") as f:
+                f.write(content)
+
+    return install
+
+
+def emit(lldpd, lldpcli, *tlvs):
+    """Start an lldpd advertising the given (oui, subtype, payload) TLVs."""
+    lldpd()
+    for index, (oui, subtype, payload) in enumerate(tlvs):
+        result = lldpcli(
+            *shlex.split(
+                "configure lldp custom-tlv {}oui {} subtype {} oui-info {}".format(
+                    index and "add " or "", oui.replace(":", ","), subtype, payload
+                )
+            )
+        )
+        assert result.returncode == 0
+    time.sleep(3)
+
+
+def neighbors(lldpcli, prefix="lldp.eth0."):
+    out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
+    return {k[len(prefix) :]: v for k, v in out.items() if k.startswith(prefix)}
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+@pytest.mark.parametrize(
+    "fields, oui_info, expected",
+    [
+        ("string", "41,42,43,31,32,33", "ABC123"),
+        ("uint8", "07", "7"),
+        ("uint16", "01,2C", "300"),
+        ("uint32", "00,00,01,2C", "300"),
+        ("ipv4", "C0,A8,01,0A", "192.168.1.10"),
+        ("mac", "00,11,22,33,44,55", "00:11:22:33:44:55"),
+        ("hex", "DE,AD,BE,EF", "DE,AD,BE,EF"),
+    ],
+)
+def test_org_tlv_field_types(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf, fields, oui_info, expected
+):
+    """Each supported field type is decoded according to the definition."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, oui_info))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Test Field", fields, vendor="Testvendor")
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.value"] == expected
+    # The raw hex fallback must not be used when a definition matched.
+    assert not [k for k in out if k.startswith("unknown-tlvs.")]
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_named_fields(lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf):
+    """A definition with several named fields splits the payload."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 2, "01,00,50,C0,A8,01,0A"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(
+                OUI,
+                2,
+                "Uplink",
+                "uint8:status, uint16:port, ipv4:address",
+                vendor="Testvendor",
+            )
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.status"] == "1"
+    assert out["testvendor-tlvs.org-tlv.port"] == "80"
+    assert out["testvendor-tlvs.org-tlv.address"] == "192.168.1.10"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_same_vendor_shares_one_group(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """Several subtypes of one OUI are decoded under the same vendor group."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "07"), (OUI, 2, "01,00,50"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Alpha", "uint8:alpha", vendor="Testvendor")
+            + definition(OUI, 2, "Beta", "uint8:beta, uint16:port")
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.org-tlv.alpha"] == "7"
+    assert out["testvendor-tlvs.org-tlv.beta"] == "1"
+    assert out["testvendor-tlvs.org-tlv.port"] == "80"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_definitions_from_several_files(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """Every .conf file is loaded and each vendor gets its own group."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42,43"), (OTHER_OUI, 1, "44,45,46"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "First", "string", vendor="Testvendor"),
+            othervendor=definition(
+                OTHER_OUI, 1, "Second", "string", vendor="Othervendor"
+            ),
+        )
+        out = neighbors(lldpcli)
+    assert out["testvendor-tlvs.value"] == "ABC"
+    assert out["othervendor-tlvs.value"] == "DEF"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_without_vendor_is_unknown(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """Without a vendor section the TLV is decoded under "Unknown TLVs"."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 1, "41,42,43"))
+    with namespaces(1):
+        org_tlv_conf(testvendor=definition(OUI, 1, "Test Field", "string"))
+        out = neighbors(lldpcli)
+    assert out["unknown-tlvs.value"] == "ABC"
+
+
+@pytest.mark.skipif(
+    "'Custom TLV' not in config.lldpd.features", reason="Custom TLV not supported"
+)
+def test_org_tlv_no_definition_falls_back_to_hex(
+    lldpd1, lldpd, lldpcli, namespaces, org_tlv_conf
+):
+    """An unmatched TLV keeps the previous raw hex rendering."""
+    with namespaces(2):
+        emit(lldpd, lldpcli, (OUI, 9, "45,45,45"))
+    with namespaces(1):
+        org_tlv_conf(
+            testvendor=definition(OUI, 1, "Test Field", "string", vendor="Testvendor")
+        )
+        out = neighbors(lldpcli)
+    assert out["unknown-tlvs.unknown-tlv.oui"] == "00,11,22"
+    assert out["unknown-tlvs.unknown-tlv.subtype"] == "9"
+    assert out["unknown-tlvs.unknown-tlv"] == "45,45,45"


### PR DESCRIPTION
**Note**: my apologies, this is a re-attempt for https://github.com/lldpd/lldpd/pull/769 (git-related L8 issues)

---

Add config-driven interpretation of organizational TLVs (Type 127) in lldpcli. TLVs from vendors whose OUI is not natively handled are normally shown as raw hex. This change introduces a three-tier lookup:

1. Code handlers (compiled) for complex TLVs like Cisco ACI SubType 207
2. INI-style config files for simple flat TLVs (field type + label)
3. Hex fallback (unchanged default behavior)

Config files are read from SYSCONFDIR/lldpd.d/org-tlvs.conf.d/*.conf and support field types: uint8, uint16, uint32, string, ipv4, mac, hex. Multi-field definitions with named labels are supported.

Ship Cisco ACI and Juniper TLV definitions by default. This is entirely client-side — no daemon, IPC, or struct changes.

New files:
  src/client/org_tlv_handler.{h,c} — code handler registry
  src/client/org_tlv_handler_cisco.c — Cisco ACI handler (SubType 207)
  src/client/org_tlv_conf.{h,c} — INI parser, config loading, display
  src/client/org-tlvs.conf.d/ — shipped config files

Modified files:
  src/client/display.c — three-tier lookup in display_custom_tlvs()
  src/client/lldpcli.c — init handlers and load config at startup
  src/client/Makefile.am — add new sources, SYSCONFDIR, install target
  src/client/lldpcli.8.in — document ORGANIZATIONAL TLV DISPLAY section
  NEWS — changelog entry