### PR TITLE
Fix heap OOB read in VLAN decapsulation memmove

### DIFF
--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -574,7 +574,7 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s, struct lldpd_hardware *hardw
 		/* VLAN decapsulation means to shift 4 bytes left the frame from
 		 * offset 2*ETHER_ADDR_LEN */
 		memmove(frame + 2 * ETHER_ADDR_LEN, frame + 2 * ETHER_ADDR_LEN + 4,
-		    s - 2 * ETHER_ADDR_LEN);
+		    s - 2 * ETHER_ADDR_LEN - 4);
 		s -= 4;
 	}
 


### PR DESCRIPTION
## Summary

In `lldpd_decode()`, the VLAN decapsulation `memmove` shifts frame data 4 bytes left starting at offset `2*ETHER_ADDR_LEN`. The source pointer is correctly offset by +4, but the length argument uses the full remaining frame length (`s - 2*ETHER_ADDR_LEN`) instead of accounting for the 4-byte shift (`s - 2*ETHER_ADDR_LEN - 4`).

When the received frame fills the hardware MTU allocation exactly, the `memmove` source range extends 4 bytes past the end of the heap buffer.

## Fix

Subtract the 4-byte VLAN tag size from the `memmove` length, matching the source offset adjustment.