### PR TITLE
Fix mixup between single and dual signature in strings.

### DIFF
--- a/src/lib/atoms/dot3.c
+++ b/src/lib/atoms/dot3.c
@@ -77,8 +77,8 @@ static struct atom_map port_dot3_power_pse_status_map = {
 	.map = {
 		{ 0, "unknown" },
 		{ 1, "2-pair powering" },
-		{ 2, "4-pair powering dual-signature PD" },
-		{ 3, "4-pair powering single-signature PD" },
+		{ 2, "4-pair powering single-signature PD" },
+		{ 3, "4-pair powering dual-signature PD" },
 		{ 0, NULL },
 	},
 };
@@ -87,9 +87,9 @@ static struct atom_map port_dot3_power_pd_status_map = {
 	.key = lldpctl_k_dot3_power_pd_status,
 	.map = {
 		{ 0, "unknown" },
-		{ 1, "2-pair powered PD" },
-		{ 2, "4-pair powered dual-signature PD" },
-		{ 3, "4-pair powered single-signature PD" },
+		{ 1, "Powered single-signature PD" },
+		{ 2, "2-pair powered dual-signature PD" },
+		{ 3, "4-pair powered dual-signature PD" },
 		{ 0, NULL },
 	},
 };

--- a/tests/integration/test_pcap.py
+++ b/tests/integration/test_pcap.py
@@ -75,7 +75,7 @@ def test_8023bt(lldpd1, lldpcli, namespaces):
             "lldp.eth0.port.power.requested-b": "35500",
             "lldp.eth0.port.power.allocated-a": "25500",
             "lldp.eth0.port.power.allocated-b": "25500",
-            "lldp.eth0.port.power.pse-powering-status": "4-pair powering single-signature PD",
+            "lldp.eth0.port.power.pse-powering-status": "4-pair powering dual-signature PD",
             "lldp.eth0.port.power.pd-powering-status": "unknown",
             "lldp.eth0.port.power.power-pairs-ext": "both alternatives",
             "lldp.eth0.port.power.power-class-ext-a": "class 4",


### PR DESCRIPTION
The strings describing POE 802.3bt single and dual signature PDs was mixed up when decoding from table 802.3-2022 table 79-14.